### PR TITLE
Document build.bat hang issue

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -98,3 +98,12 @@ creates the database for you using SQL scripts, inserts organization name and co
         * ASP.NET 4.7
         * ISAPI Extensions
         * ISAPI Filters
+        
+1. build.bat hangs on "Preparing to run build script..."
+
+    * Inspect your NuGet package sources. One way of doing that is by running "nuget sources" command
+    * Disable NuGet package sources that require authentication. Ideally, you should enable only nuget.org as a source
+    * Run build.bat as administrator
+    * Enable the disabled packages after installation is complete
+
+    


### PR DESCRIPTION
Encountered and resolved an issue that could be added to Installation Troubleshooting documentation.

While running build.bat, it used to hang on "Preparing to run build script..."

Inspected build.ps1 script and it hung on
`Write-Host $NUGET_EXE +" install -ExcludeVersion -OutputDirectory "+$TOOLS_DIR`

Looked into my NuGet package sources and there were some personal sources which requires authentication. Had to disable those and leave only https://www.nuget.org/api/v2/ to finish the installation.