### PR TITLE
Incorrect connection string suggestion when running build.bat

### DIFF
--- a/build/generator-simoona/app/index.js
+++ b/build/generator-simoona/app/index.js
@@ -69,7 +69,7 @@ module.exports = class extends Generator {
           type    : 'input',
           name    : 'connectionString',
           message : 'Enter database server connection string (without database name):',
-          default : "Data Source=localhost\SQLEXPRESS;Integrated Security=True;Connect Timeout=60; MultipleActiveResultSets=True;",
+          default : "Data Source=localhost\\SQLEXPRESS;Integrated Security=True;Connect Timeout=60; MultipleActiveResultSets=True;",
           validate: function (connectionString){
             var conn = connectionString.toLowerCase();
             return conn !== '';


### PR DESCRIPTION
Backslash is not escaped in the build script hence the suggested connection string is incorrect:

![image](https://user-images.githubusercontent.com/15982857/56222631-0bfbc400-6075-11e9-9adf-831b09156360.png)
