### PR TITLE
Fixed pending kudos status check for deleting user functionality.

### DIFF
--- a/src/api/Main/BuisnessLayer/Shrooms.Domain/Services/Kudos/KudosService.cs
+++ b/src/api/Main/BuisnessLayer/Shrooms.Domain/Services/Kudos/KudosService.cs
@@ -512,7 +512,8 @@ namespace Shrooms.Domain.Services.Kudos
 
         public bool HasPendingKudos(string employeeId)
         {
-            IList<KudosLog> kudosLogs = _kudosLogsDbSet.Where(e => e.EmployeeId == employeeId).ToList();
+            IList<KudosLog> kudosLogs = _kudosLogsDbSet.Where(e =>  e.EmployeeId == employeeId &&
+                                                                    e.Status == KudosStatus.Pending).ToList();
 
             return kudosLogs.Any();
         }

--- a/src/api/Tests/Shrooms.Tests/DomainService/KudosServiceTests.cs
+++ b/src/api/Tests/Shrooms.Tests/DomainService/KudosServiceTests.cs
@@ -493,6 +493,26 @@ namespace Shrooms.API.Tests.DomainService
 
         #endregion
 
+        #region HasPendingKudos
+
+        [Test]
+        public void HasPendingKudos_Should_Return_True()
+        {
+            MockKudosLogsForStats();
+            var actual = _kudosService.HasPendingKudos("User1");
+            Assert.AreEqual(true, actual);
+        }
+
+        [Test]
+        public void HasPendingKudos_Should_Return_False()
+        {
+            MockKudosLogsForStats();
+            var actual = _kudosService.HasPendingKudos("User2");
+            Assert.AreEqual(false, actual);
+        }
+
+        #endregion
+
         #region MockData
 
         private static void MockRoleService(IRoleService roleService)


### PR DESCRIPTION
Fixed bug. Currently we can't delete any user who has any kind of Kudos. It should be narrowed down only to Pending Kudos.