### PR TITLE
Change markdown-suggestion class' font-family to sans-serif

### DIFF
--- a/src/webapp/src/client/styles/style/modules/_modules-other.less
+++ b/src/webapp/src/client/styles/style/modules/_modules-other.less
@@ -757,6 +757,7 @@ div.post-text-container {
     font-size: 10px;
     padding-right: 10px;
     padding-bottom: 2px;
+    font-family: sans-serif;
 }
 
 .panel-footer-post {


### PR DESCRIPTION
Changed markdown-suggestion class' font-family to sans-serif to make tilde more visible.

Before:

![image](https://user-images.githubusercontent.com/15982857/60371955-9e203100-9a03-11e9-8d89-33890e523888.png)

After:

![image](https://user-images.githubusercontent.com/15982857/60371927-821c8f80-9a03-11e9-984e-5138856b0195.png)

Also consider increasing font-size, making font-weight bold, etc. instead of changing font-family. In the example, I increased font-size from 10px to 12px:

![image](https://user-images.githubusercontent.com/15982857/60372318-f441a400-9a04-11e9-8464-1e3bd2f66726.png)
