### PR TITLE
Markdown fixes

### DIFF
--- a/src/api/Main/BuisnessLayer/Shrooms.Domain/Helpers/CommonMarkMarkdownConverter.cs
+++ b/src/api/Main/BuisnessLayer/Shrooms.Domain/Helpers/CommonMarkMarkdownConverter.cs
@@ -13,6 +13,7 @@ namespace Shrooms.Domain.Helpers
         {
             var settings = CommonMarkSettings.Default;
             settings.AdditionalFeatures |= CommonMarkAdditionalFeatures.StrikethroughTilde;
+            settings.RenderSoftLineBreaksAsLineBreaks = true;
             return settings;
         }
 

--- a/src/api/Main/PresentationLayer/Shrooms.API/Controllers/BaseController.cs
+++ b/src/api/Main/PresentationLayer/Shrooms.API/Controllers/BaseController.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNet.Identity;
 using Shrooms.API.Helpers;
 using Shrooms.DataTransferObjects.Models;
 using Shrooms.DomainExceptions.Exceptions;
-using Shrooms.API.GeneralCode;
 
 namespace Shrooms.API.Controllers
 {

--- a/src/api/Main/PresentationLayer/Shrooms.API/EmailTemplates/Wall/NewComment.cshtml
+++ b/src/api/Main/PresentationLayer/Shrooms.API/EmailTemplates/Wall/NewComment.cshtml
@@ -40,7 +40,7 @@
                         <!-- DYNAMIC WALL POST USER DISPLAY END -->
 
                         <p style="color: #282828;text-align: left;font-size: 14px;padding-left: 10px;padding-bottom: 15px;font-weight: 400;word-wrap: break-word;word-break: break-all; word-break: break-word;overflow-wrap: break-word; font-family: 'Segoe UI',Helvetica,Arial,sans-serif;margin: 0 0 0 0;">
-                            @Raw(HtmlSanitizerHelper.Sanitize(Model.MessageBody).Replace("\n", "<br>"))
+                            @Raw(HtmlSanitizerHelper.Sanitize(Model.MessageBody))
                         </p>
                     </td>
                 </tr>

--- a/src/api/Main/PresentationLayer/Shrooms.API/EmailTemplates/Wall/NewPost.cshtml
+++ b/src/api/Main/PresentationLayer/Shrooms.API/EmailTemplates/Wall/NewPost.cshtml
@@ -40,7 +40,7 @@
                         <!-- DYNAMIC WALL POST USER DISPLAY END -->
 
                         <p style="color: #282828;text-align: left;font-size: 14px;padding-left: 10px;padding-bottom: 15px;font-weight: 400;word-wrap: break-word;word-break: break-all; word-break: break-word;overflow-wrap: break-word; font-family: 'Segoe UI',Helvetica,Arial,sans-serif;margin: 0 0 0 0;">
-                            @Raw(HtmlSanitizerHelper.Sanitize(Model.MessageBody).Replace("\n", "<br>"))
+                            @Raw(HtmlSanitizerHelper.Sanitize(Model.MessageBody))
                         </p>
                     </td>
                 </tr>

--- a/src/webapp/src/client/app/common/directives/markdown.directive.js
+++ b/src/webapp/src/client/app/common/directives/markdown.directive.js
@@ -1,4 +1,4 @@
-﻿(function () {
+(function () {
     'use strict';
 
     angular.module('simoonaApp.Common')
@@ -13,29 +13,33 @@
         return directive;
         function linkFunc (scope, element, attrs) {
 
-            scope.$evalAsync(function(){
-                var converter = new showdown.Converter();
-                changeSettings(converter);
-                var text = element[0].innerHTML;
-                var convertedText = linkValidator(text, converter);
-                convertedText = convertedText.toString().replace(/&lt;br&gt;/g, '<br>'); //changes all shown <br>'s with actual line break
-                element[0].innerHTML = convertedText;
+            scope.$evalAsync(function() {
+                const text = convertMarkdownToHtml(element[0].innerHTML);
+                element[0].innerHTML = text;
             })
 
-            function changeSettings(converter){
-                converter.setOption('strikethrough', true);
-                converter.setOption('underline', true);
+            function convertMarkdownToHtml(input) {
+                const converterInput = input.replace('&gt;', '>'); // Sanitizer encodes this, needed for blockquote.
+                return getMarkdownConverter().makeHtml(converterInput);
             }
 
-            function linkValidator(text, converter) {
-                var reg = /(<a.*?<\/a>)/g;
-                // text splits into array with elements and every second one is link which is not modified to markdowns and emojis
-                var textAndLinks = text.split(reg);
-                for (var i = 0; i < textAndLinks.length; i = i + 2){
-                    textAndLinks[i] = converter.makeHtml(textAndLinks[i]);
-                }
-                var result = textAndLinks.join('');
-                return result;
+            function getMarkdownConverter() {
+                const converter = new showdown.Converter();
+                changeSettings(converter);
+                return converter;
+            }
+
+            function changeSettings(converter) {
+                const enabledFeatures = [
+                    'excludeTrailingPunctuationFromURLs',
+                    'openLinksInNewWindow',
+                    'requireSpaceBeforeHeadingText',
+                    'simpleLineBreaks',
+                    'simplifiedAutoLink',
+                    'strikethrough',
+                    'underline'
+                ];
+                enabledFeatures.forEach(option => converter.setOption(option, true));
             }
         }
     }

--- a/src/webapp/src/client/app/common/directives/wall/message-show-more/message-show-more.html
+++ b/src/webapp/src/client/app/common/directives/wall/message-show-more/message-show-more.html
@@ -1,8 +1,8 @@
 ﻿<div class="post-text-container">
 	<span ng-if="!hasHashtagify" markdown
-	      ng-bind-html="newMessage | linky: '_blank' | newlineToBr"></span>
+	      ng-bind-html="newMessage"></span>
 	<span ng-if="!!hasHashtagify" markdown
-		  ng-bind-html="newMessage | linky: '_blank' | newlineToBr" 
+		  ng-bind-html="newMessage" 
 		  hashtagify="tagTermClick($event)"></span>
 	<span class="show-more-container"></span>
 </div>

--- a/src/webapp/src/client/app/events/content/description/description.html
+++ b/src/webapp/src/client/app/events/content/description/description.html
@@ -64,7 +64,7 @@
             <div class="clearfix"></div>
         </div>
         <div class="col-xs-12 event-details-description" ng-show="!!vm.event.description.length">
-            <p ng-bind-html="vm.event.description | linky: '_blank' | newlineToBr"></p>
+            <p markdown ng-bind-html="vm.event.description"></p>
         </div>
     </div>
 </div>

--- a/src/webapp/src/client/app/hashtags/hashtagify.directive.js
+++ b/src/webapp/src/client/app/hashtags/hashtagify.directive.js
@@ -22,7 +22,7 @@
                     }
 
                     if (attrs.hashtagify) {
-                        var regex = XRegExp('(?:\\s|^)#([a-z0-9_\\p{L}]+)', 'g');
+                        var regex = XRegExp('(?:\\s|^|\<p\>)#([a-z0-9_\\p{L}]+)', 'g');
 
                         html = html.replace(regex, ' <a ng-click="tagClick({$event: $event})" class="hashtag">#$1</a>');
                     }


### PR DESCRIPTION
- Fixed weird formatting issues on webapp.
- Fixed hashtag support - titles will need to have a whitespace after the # sign. It means that `# Title` will translate to a heading, while `#title` will translate to a hashtag.
- Added markdown support to event description.