### PR TITLE
Fixed Kudos sender to empty if it was sent by bot

### DIFF
--- a/src/api/Main/BuisnessLayer/Shrooms.Domain/Services/Kudos/KudosService.cs
+++ b/src/api/Main/BuisnessLayer/Shrooms.Domain/Services/Kudos/KudosService.cs
@@ -214,7 +214,7 @@ namespace Shrooms.Domain.Services.Kudos
                                Status = kudLog.Status.ToString(),
                                Sender = new KudosLogUserDTO
                                {
-                                   FullName = usr == null ? kudLog.CreatedBy : usr.FirstName + " " + usr.LastName,
+                                   FullName = usr == null ? string.Empty : usr.FirstName + " " + usr.LastName,
                                    Id = usr == null ? string.Empty : kudLog.CreatedBy
                                },
                                PictureId = kudLog.PictureId


### PR DESCRIPTION
Fixed Kudos sender to be empty if it was sent by bot, avoiding SQL collation issues in select statement