### PR TITLE
Bugfix - mark as read notification check

### DIFF
--- a/src/webapp/src/client/app/common/directives/wall/posts/post.component.js
+++ b/src/webapp/src/client/app/common/directives/wall/posts/post.component.js
@@ -82,7 +82,7 @@
                         notificationIds.push(notification.id);
                     }
                 });
-                if(!!notificationIds)
+                if(!!notificationIds.length)
                 {
                     vm.markAsRead(notificationIds);
                     notificationIds = [];


### PR DESCRIPTION
Fix mark as read notification check.
Sends request to back end only if 'notificationIds' array is not empty instead of sending each time