### PR TITLE
Fix lottery stats only visible when lottery status is started

### DIFF
--- a/src/webapp/src/client/app/lotteries/lottery-manage.html
+++ b/src/webapp/src/client/app/lotteries/lottery-manage.html
@@ -7,7 +7,6 @@
                     <span ng-if="vm.states.isCreate" 
                           translate="lotteries.createLottery"></span>
                     <button
-                          ng-if="vm.isStarted"
                           class="btn btn-primary lottery-stats-button"
                           ace-lottery-stats-modal>
                     <span translate="lotteries.lotteryStatsModalName"></span>


### PR DESCRIPTION
Lottery stats are visible to admins at any moment.