### PR TITLE
Fix update event without image

### DIFF
--- a/src/webapp/src/client/app/config.js
+++ b/src/webapp/src/client/app/config.js
@@ -43,7 +43,7 @@
     ];
 
     window.modules = modulesList;
-    window.isPremium = false; // Enable/disable premium modules
+    window.isPremium = true; // Enable/disable premium modules
     window.lotteriesEnabled = false;
     window.usingAnimatedGifs = false; // Used to determine if back-end uses AnimatedGifs plugin
     window.usePostWatching = true; // Used to show/hide post watching feature

--- a/src/webapp/src/client/app/config.js
+++ b/src/webapp/src/client/app/config.js
@@ -43,7 +43,7 @@
     ];
 
     window.modules = modulesList;
-    window.isPremium = true; // Enable/disable premium modules
+    window.isPremium = false; // Enable/disable premium modules
     window.lotteriesEnabled = false;
     window.usingAnimatedGifs = false; // Used to determine if back-end uses AnimatedGifs plugin
     window.usePostWatching = true; // Used to show/hide post watching feature

--- a/src/webapp/src/client/app/events/create-edit/create-edit.controller.js
+++ b/src/webapp/src/client/app/events/create-edit/create-edit.controller.js
@@ -229,9 +229,8 @@
             }
         }
 
-        function saveEvent(method, NewImage) {
-            
-            if (NewImage.length) {
+        function saveEvent(method, newImage) {
+            if (newImage.length) {
                 var eventImageBlob = dataHandler.dataURItoBlob(vm.eventCroppedImage[0], vm.eventImage[0].type);
 
                 eventImageBlob.lastModifiedDate = new Date();

--- a/src/webapp/src/client/app/events/create-edit/create-edit.controller.js
+++ b/src/webapp/src/client/app/events/create-edit/create-edit.controller.js
@@ -229,8 +229,9 @@
             }
         }
 
-        function saveEvent(method, isImageChanged) {
-            if (isImageChanged) {
+        function saveEvent(method, NewImage) {
+            
+            if (NewImage.length) {
                 var eventImageBlob = dataHandler.dataURItoBlob(vm.eventCroppedImage[0], vm.eventImage[0].type);
 
                 eventImageBlob.lastModifiedDate = new Date();

--- a/src/webapp/src/client/app/events/create-edit/create-edit.html
+++ b/src/webapp/src/client/app/events/create-edit/create-edit.html
@@ -251,13 +251,13 @@
                     </div>
                     <!--event buttons right -->
                     <div class="pull-right">
-                        <button class="btn btn-primary" ng-if="vm.states.isAdd" ng-click="vm.saveEvent(vm.createEvent, true)" ng-disabled="eventForm.$invalid ||  !vm.eventImage || !vm.responsibleUser.id ||
+                        <button class="btn btn-primary" ng-if="vm.states.isAdd" ng-click="vm.saveEvent(vm.createEvent, vm.eventImage)" ng-disabled="eventForm.$invalid ||  !vm.eventImage || !vm.responsibleUser.id ||
                                          !vm.isEndDateValid() || vm.isDeadlineDateValid() || !vm.isStartDateValid() ||
                                          !vm.isOptionsUnique() || !vm.eventCroppedImage" data-test-id="event-form-save-button">
                             <span translate="common.save"></span>
                         </button>
-                        <button class="btn btn-primary" ng-if="vm.states.isEdit" ng-click="vm.saveEvent(vm.updateEvent, !!vm.eventImage)" ng-disabled="eventForm.$invalid || !vm.responsibleUser.id || !vm.isEndDateValid() ||
-                                         vm.isDeadlineDateValid() || !vm.isOptionsUnique() || (!!vm.eventImage && !vm.eventCroppedImage)" data-test-id="event-form-update-button">
+                        <button class="btn btn-primary" ng-if="vm.states.isEdit" ng-click="vm.saveEvent(vm.updateEvent, vm.eventImage)" ng-disabled="eventForm.$invalid || !vm.responsibleUser.id || !vm.isEndDateValid() ||
+                                         vm.isDeadlineDateValid() || !vm.isOptionsUnique()" data-test-id="event-form-update-button">
                             <span translate="common.update"></span>
                         </button>
                         <button class="btn btn-default" ui-sref="Root.WithOrg.Client.Events.List.Type({type: 'all'})" data-test-id="event-form-cancel-button">


### PR DESCRIPTION
- Fix updated event validation check.

![eventUpdateBug](https://user-images.githubusercontent.com/51354779/68943884-19b52b80-07b5-11ea-8ad3-216b9f02ea8b.gif)

Update is now checked with length and not boolean value.

When sending empty array and converting it to bool (**!!vm.eventImage**) it's converted to true

**[ ] == true**

`(!!vm.eventImage && !vm.eventCroppedImage)` check is unnecessary because event creator cannot remove picture, only change it.