### PR TITLE
fix crashes on user's profile edit

### DIFF
--- a/src/api/Main/PresentationLayer/Shrooms.API/Controllers/UserDeprecatedController.cs
+++ b/src/api/Main/PresentationLayer/Shrooms.API/Controllers/UserDeprecatedController.cs
@@ -662,7 +662,10 @@ namespace Shrooms.API.Controllers.WebApi
                 return Request.CreateResponse(HttpStatusCode.BadRequest, new[] { string.Format(Resources.Models.ApplicationUser.ApplicationUser.EmailAlreadyExsists) });
             }
 
-            await _pictureService.RemoveImage(user.PictureId, userOrg.OrganizationId);
+            if (user.PictureId != model.PictureId)
+            {
+                await _pictureService.RemoveImage(user.PictureId, userOrg.OrganizationId);
+            }
 
             _mapper.Map(model, user);
             _applicationUserRepository.Update(user);


### PR DESCRIPTION
User's profile picture is deleted after profile update because if user is ever deleted and anonymized there is no way to track his all profile photos, but just the last one. However, there wasn't any checking if picture was changed to a new one before deleting the last photo, which caused the problem.