### PR TITLE
Add get kudos type as no tracking

### DIFF
--- a/src/api/Main/BuisnessLayer/Shrooms.Domain/Services/Kudos/KudosService.cs
+++ b/src/api/Main/BuisnessLayer/Shrooms.Domain/Services/Kudos/KudosService.cs
@@ -499,7 +499,7 @@ namespace Shrooms.Domain.Services.Kudos
 
         private bool UserHasPermission(AddKudosLogDTO kudosDto)
         {
-            var kudosType = _kudosTypesDbSet.Find(kudosDto.PointsTypeId);
+            var kudosType = _kudosTypesDbSet.AsNoTracking().FirstOrDefault(p => p.Id == kudosDto.PointsTypeId);
             if (kudosType is null)
             {
                 return false;
@@ -742,7 +742,7 @@ namespace Shrooms.Domain.Services.Kudos
             var sendingUser = _usersDbSet.Find(kudosLog.UserId);
             _kudosServiceValidator.ValidateUser(sendingUser);
 
-            var kudosType = _kudosTypesDbSet.Find(kudosLog.PointsTypeId);
+            var kudosType = _kudosTypesDbSet.AsNoTracking().FirstOrDefault(p => p.Id == kudosLog.PointsTypeId);
             _kudosServiceValidator.ValidateKudosType(kudosType);
 
             return new AddKudosDTO
@@ -835,8 +835,7 @@ namespace Shrooms.Domain.Services.Kudos
 
         private AddKudosDTO GenerateLogForKudosMinusOperation(AddKudosDTO kudosDTO)
         {
-            var minusKudosType = _kudosTypesDbSet
-                    .FirstOrDefault(n => n.Type == KudosTypeEnum.Minus);
+            var minusKudosType = _kudosTypesDbSet.AsNoTracking().FirstOrDefault(n => n.Type == KudosTypeEnum.Minus);
 
             var kudosLogForMinusKudos = new AddKudosLogDTO
             {

--- a/src/api/Main/PresentationLayer/Shrooms.API/Controllers/Kudos/KudosController.cs
+++ b/src/api/Main/PresentationLayer/Shrooms.API/Controllers/Kudos/KudosController.cs
@@ -196,6 +196,7 @@ namespace Shrooms.API.Controllers.Kudos
             }
 
             var dto = _mapper.Map<KudosTypeViewModel, KudosTypeDTO>(model);
+            SetOrganizationAndUser(dto);
 
             try
             {


### PR DESCRIPTION
- Added AsNoTracking to ignore it from caching it in DbContext
- Fixed EditType endpoint. User and organization was not set earlier, because of that column ModifiedBy in table KudosTypes was NULL. Now it should show user id who modified kudos type.