### PR TITLE
Add event description with link to event redirect

### DIFF
--- a/src/webapp/src/client/app/events/calendar/calendar-btn.component.js
+++ b/src/webapp/src/client/app/events/calendar/calendar-btn.component.js
@@ -32,7 +32,7 @@
             var googleCalendarEndDate = vm.calendarItem.endDate.replace(/-|:|\.\d\d\d/g,"");
 
             var title = encodeURIComponent(vm.calendarItem.name);
-            var details = encodeURIComponent(`${vm.calendarItem.description} \n\n ${$location.absUrl()}`);
+            var details = encodeURIComponent(`${vm.calendarItem.description}\n\n${$location.absUrl()}`);
             var location = encodeURIComponent(vm.calendarItem.location);
             
             vm.googleCalendarRedirect = `${googleCalendarBaseUrl}&text=${title}&location=${location}&dates=${googleCalendarStartDate}Z/${googleCalendarEndDate}Z&details=${details}`;    

--- a/src/webapp/src/client/app/events/calendar/calendar-btn.component.js
+++ b/src/webapp/src/client/app/events/calendar/calendar-btn.component.js
@@ -15,10 +15,11 @@
 
     calendarButtonController.$inject = [
             'googleCalendarBaseUrl',
-            'eventRepository'
+            'eventRepository',
+            '$location'
         ];
 
-    function calendarButtonController(googleCalendarBaseUrl, eventRepository) {
+    function calendarButtonController(googleCalendarBaseUrl, eventRepository, $location) {
         /*jshint validthis: true */
         var vm = this;
 
@@ -29,7 +30,12 @@
         function setupRedirectLinks() {
             var googleCalendarStartDate = vm.calendarItem.startDate.replace(/-|:|\.\d\d\d/g,"");
             var googleCalendarEndDate = vm.calendarItem.endDate.replace(/-|:|\.\d\d\d/g,"");
-            vm.googleCalendarRedirect = `${googleCalendarBaseUrl}&text=${vm.calendarItem.name}&location=${vm.calendarItem.location}&dates=${googleCalendarStartDate}Z/${googleCalendarEndDate}Z`;    
+
+            var title = encodeURIComponent(vm.calendarItem.name);
+            var details = encodeURIComponent(`${vm.calendarItem.description} \n\n ${$location.absUrl()}`);
+            var location = encodeURIComponent(vm.calendarItem.location);
+            
+            vm.googleCalendarRedirect = `${googleCalendarBaseUrl}&text=${title}&location=${location}&dates=${googleCalendarStartDate}Z/${googleCalendarEndDate}Z&details=${details}`;    
         }
 
         function downloadEvent() {


### PR DESCRIPTION
- Added description with link containing current event

Cannot encode whole URI, because all '&' signs will be encoded and separation between different parameters will be removed, so every component containing possible escape characters have to be encoded separately.

![eventRedi](https://user-images.githubusercontent.com/51354779/72072773-5144dd80-32f7-11ea-9ce0-5619ef26a404.gif)
