### PR TITLE
Fix create kudos disabled check

### DIFF
--- a/src/webapp/src/client/app/customization/kudos-types/create-edit/create-edit.controller.js
+++ b/src/webapp/src/client/app/customization/kudos-types/create-edit/create-edit.controller.js
@@ -18,6 +18,7 @@
 
         if(vm.states.isCreate) {
             $rootScope.pageTitle = 'customization.createKudosType';
+            vm.isEditable = true;
         } else {
             $rootScope.pageTitle = 'customization.editKudosTypes';
         }
@@ -42,10 +43,9 @@
                         vm.kudosType.multiplier = parseInt(type.value);
                         vm.kudosType.description = type.description;
                         vm.kudosType.isActive = type.isActive;
-                        
-                        vm.isEditable = type.type === definedKudosTypes.ordinary ? true : false;
-                        vm.isVisibilityToggleable = type.type !== definedKudosTypes.send ? true : false;
                         vm.isLoading = false;
+                        if(vm.states.isEdit) {vm.isEditable = type.type === definedKudosTypes.ordinary ? true : false;}
+                        vm.isVisibilityToggleable = type.type !== definedKudosTypes.send ? true : false;
                     }, function (error) {
                     errorHandler.handleErrorMessage(error);
                     $state.go(listState);


### PR DESCRIPTION
- Fixed bug when trying to create new kudos type. All fields were disabled due to isEnabled flag being false. isEditable check is now scoped within Edit state