### PR TITLE
Fix kudos photo icon when text is long

### DIFF
--- a/src/webapp/src/client/styles/style/modules/_kudos.less
+++ b/src/webapp/src/client/styles/style/modules/_kudos.less
@@ -489,7 +489,7 @@
         }
 
         .kudos-activity-log-comment {
-            max-width: 275px;
+            max-width: 245px;
             font-size: 13px;
             flex: 1 1 100%;
             height: 37px;


### PR DESCRIPTION
Fix visual bug, when text is too long

Bug:

![image](https://user-images.githubusercontent.com/51354779/84004621-7efc8400-a974-11ea-9340-003eb98e60c0.png)


After fix:

![image](https://user-images.githubusercontent.com/51354779/84004534-5aa0a780-a974-11ea-97b1-20c9ba9345d0.png)
