### PR TITLE
Remove markdown when creating mention

### DIFF
--- a/src/webapp/src/client/app/common/directives/markdown.directive.js
+++ b/src/webapp/src/client/app/common/directives/markdown.directive.js
@@ -14,8 +14,8 @@
         function linkFunc (scope, element, attrs) {
 
             scope.$evalAsync(function() {
-                const text = convertMarkdownToHtml(element[0].innerHTML);
-                element[0].innerHTML = text;
+                let text = convertMarkdownToHtml(element[0].innerHTML);
+                element[0].innerHTML = formatMentions(text);;
             })
 
             function convertMarkdownToHtml(input) {
@@ -40,6 +40,19 @@
                     'underline'
                 ];
                 enabledFeatures.forEach(option => converter.setOption(option, true));
+            }
+
+            function formatMentions(text) {
+                var pattern = /\B@[a-z0-9_-]+/gi;
+                var matches = text.match(pattern);
+
+                if (matches) {
+                    matches.forEach(function(cur) {
+                        text = text.replace(cur, `<strong> ${cur} </strong>`);
+                    });
+                }
+
+                return text;
             }
         }
     }

--- a/src/webapp/src/client/app/common/directives/markdown.directive.js
+++ b/src/webapp/src/client/app/common/directives/markdown.directive.js
@@ -15,7 +15,7 @@
 
             scope.$evalAsync(function() {
                 let text = convertMarkdownToHtml(element[0].innerHTML);
-                element[0].innerHTML = formatMentions(text);;
+                element[0].innerHTML = formatMentions(text);
             })
 
             function convertMarkdownToHtml(input) {

--- a/src/webapp/src/client/app/common/directives/wall/comments/comment-create/comment-create.component.js
+++ b/src/webapp/src/client/app/common/directives/wall/comments/comment-create/comment-create.component.js
@@ -89,7 +89,7 @@
         function selectMention(item) {
             vm.selectedMentions.push({id: item.id, fullName: item.label});
 
-            return `**@${item.label.replace(' ', '_')}**`;
+            return `@${item.label.replace(' ', '_')}`;
         }
 
         function invokeMention(term) {

--- a/src/webapp/src/client/app/common/directives/wall/posts/post-create/post-create.component.js
+++ b/src/webapp/src/client/app/common/directives/wall/posts/post-create/post-create.component.js
@@ -80,7 +80,7 @@
         function selectMention(item) {
             vm.selectedMentions.push({id: item.id, fullName: item.label});
 
-            return `**@${item.label.replace(' ', '_')}**`;
+            return `@${item.label.replace(' ', '_')}`;
         }
 
         function invokeMention(term) {


### PR DESCRIPTION
Currently markdown to html conversion is done by third party library. 
https://github.com/showdownjs/showdown

To remove markdown when creating mention we have to manually parse mentions when fetching posts and comments. 
There is no viable option in library for us to use, because for redirection to user's page, we need user id and not the mention text itself.

(This option is used for mentions in library)
![image](https://user-images.githubusercontent.com/51354779/90369829-12d58500-e075-11ea-9301-d6c432838b95.png)
