### PR TITLE
Fix null reference exception when sharing event without mentions

### DIFF
--- a/src/api/Shrooms.Domain/Services/Email/Posting/PostNotificationService.cs
+++ b/src/api/Shrooms.Domain/Services/Email/Posting/PostNotificationService.cs
@@ -141,6 +141,11 @@ namespace Shrooms.Domain.Services.Email.Posting
 
         private IEnumerable<ApplicationUser> GetMentionedUsers(IEnumerable<string> mentionedUsersIds)
         {
+            if (mentionedUsersIds == null)
+            {
+                yield break;
+            }
+
             foreach (var mentionId in mentionedUsersIds)
             {
                 var user = _userService.GetApplicationUser(mentionId);


### PR DESCRIPTION
Fix null reference exception when sharing event without mentions