### PR TITLE
#178 Add pictureId property to UserInfo endpoint result

### DIFF
--- a/src/api/Shrooms.Presentation.Api/Controllers/AccountController.cs
+++ b/src/api/Shrooms.Presentation.Api/Controllers/AccountController.cs
@@ -458,7 +458,8 @@ namespace Shrooms.Presentation.Api.Controllers
                 Permissions = permissions,
                 Impersonated = claimsIdentity?.Claims.Any(c => c.Type == WebApiConstants.ClaimUserImpersonation && c.Value == true.ToString()) ?? false,
                 CultureCode = user.CultureCode,
-                TimeZone = user.TimeZone
+                TimeZone = user.TimeZone,
+                PictureId = user.PictureId
             };
 
             return userInfo;

--- a/src/api/Shrooms.Presentation.WebViewModels/Models/AccountModels/LoggedInUserInfoViewModel.cs
+++ b/src/api/Shrooms.Presentation.WebViewModels/Models/AccountModels/LoggedInUserInfoViewModel.cs
@@ -23,5 +23,7 @@ namespace Shrooms.Presentation.WebViewModels.Models.AccountModels
         public string CultureCode { get; set; }
 
         public string TimeZone { get; set; }
+
+        public string PictureId { get; set; }
     }
 }


### PR DESCRIPTION
#178
Added `pictureId` property to UserInfo result as requested in `https://github.com/VismaLietuva/simoona/issues/178`
`pictureId` will be null if user does not have any picture assigned to them