### PR TITLE
Fixed markdown formatting

### DIFF
--- a/src/webapp/src/client/app/common/directives/wall/comments/comment.html
+++ b/src/webapp/src/client/app/common/directives/wall/comments/comment.html
@@ -40,7 +40,7 @@
                 </length-counter>
             </form>
 
-            <div class="message-box comment-word-break"
+            <div class="message-box"
                  ng-if="!vm.editFieldEnabled && !vm.comment.isHidden"
                  ace-message-show-more
                  has-hashtagify="vm.hasHashtagify"

--- a/src/webapp/src/client/app/common/directives/wall/message-show-more/message-show-more.directive.js
+++ b/src/webapp/src/client/app/common/directives/wall/message-show-more/message-show-more.directive.js
@@ -1,28 +1,28 @@
 (function () {
-    "use strict";
+    'use strict';
 
     angular
-        .module("simoonaApp.Common")
-        .directive("aceMessageShowMore", messageShowMore);
+        .module('simoonaApp.Common')
+        .directive('aceMessageShowMore', messageShowMore);
 
     messageShowMore.$inject = [
-        "$compile",
-        "wallService",
-        "$timeout",
-        "$window",
+        '$compile',
+        'wallService',
+        '$timeout',
+        '$window',
     ];
 
     function messageShowMore($compile, wallService, $timeout, $window) {
         var directive = {
-            restrict: "A",
+            restrict: 'A',
             templateUrl:
-                "app/common/directives/wall/message-show-more/message-show-more.html",
+                'app/common/directives/wall/message-show-more/message-show-more.html',
             scope: {
-                message: "@",
-                showMoreType: "@",
-                hasHashtagify: "=",
+                message: '@',
+                showMoreType: '@',
+                hasHashtagify: '=',
             },
-            link: linkFunc,
+            link: linkFunc
         };
         return directive;
 
@@ -36,12 +36,12 @@
             var showMoreLink =
                 '<a class="show-more-link" ng-click="showMore()" data-test-id="{{testIdShowMore}}">' +
                 '{{"wall.showMore" | translate}}' +
-                "</a>";
+                '</a>';
 
             var showLessLink =
                 '<a class="show-less-link" ng-click="showLess()" data-test-id="{{testIdShowLess}}">' +
                 '{{"wall.showLess" | translate}}' +
-                "</a>";
+                '</a>';
 
             init();
 
@@ -50,41 +50,45 @@
             function init() {
                 // using $timeout, because it will execute functions after loading DOM elements
                 $timeout(function () {
-                    if (isEllipsisActive(element.find(".post-text-container")[0])) {
+                    if (
+                        isEllipsisActive(
+                            element.find('.post-text-container')[0]
+                        )
+                    ) {
                         addShowMoreLink();
                     }
 
-                    angular.element($window).bind("resize", onResize);
+                    angular.element($window).bind('resize', onResize);
 
-                    scope.$on("$destroy", cleanUp);
+                    scope.$on('$destroy', cleanUp);
                 });
 
-                if (scope.showMoreType === "post") {
-                    scope.testIdShowMore = "post-show-more";
-                    scope.testIdShowLess = "post-show-less";
+                if (scope.showMoreType === 'post') {
+                    scope.testIdShowMore = 'post-show-more';
+                    scope.testIdShowLess = 'post-show-less';
                 } else {
-                    scope.testIdShowMore = "comment-show-more";
-                    scope.testIdShowLess = "comment-show-less";
+                    scope.testIdShowMore = 'comment-show-more';
+                    scope.testIdShowLess = 'comment-show-less';
                 }
             }
 
             function showMore() {
-                element.find(".show-more-link").remove();
+                element.find('.show-more-link').remove();
                 element
-                    .find(".post-text-container")
-                    .removeClass("show-more-message-container");
-                element.find(".show-more-container").html(showLessLink);
+                    .find('.post-text-container')
+                    .removeClass('show-more-message-container');
+                element.find('.show-more-container').html(showLessLink);
                 $compile(element.contents())(scope);
             }
 
             function showLess() {
-                element.find(".show-less-link").remove();
+                element.find('.show-less-link').remove();
                 element
-                    .find(".post-text-container")
-                    .addClass("show-more-message-container");
-                
-                if(isEllipsisActive(element.find(".post-text-container")[0])) {
-                    element.find(".show-more-container").html(showMoreLink);
+                    .find('.post-text-container')
+                    .addClass('show-more-message-container');
+
+                if (isEllipsisActive(element.find('.post-text-container')[0])) {
+                    element.find('.show-more-container').html(showMoreLink);
                 }
 
                 $compile(element.contents())(scope);
@@ -100,7 +104,9 @@
             }
 
             function onResize() {
-                var ellipsisActive = isEllipsisActive(element.find(".post-text-container")[0]);
+                var ellipsisActive = isEllipsisActive(
+                    element.find('.post-text-container')[0]
+                );
 
                 if (ellipsisActive && !isShowMoreLinkVisible) {
                     addShowMoreLink();
@@ -114,19 +120,19 @@
 
             function addShowMoreLink() {
                 $compile(
-                    element.find(".show-more-container").html(showMoreLink)
+                    element.find('.show-more-container').html(showMoreLink)
                 )(scope);
 
                 isShowMoreLinkVisible = true;
             }
 
             function removeShowMoreLink() {
-                element.find(".show-more-link").remove();
+                element.find('.show-more-link').remove();
                 isShowMoreLinkVisible = false;
             }
 
             function cleanUp() {
-                angular.element($window).off("resize", onResize);
+                angular.element($window).off('resize', onResize);
             }
         }
     }

--- a/src/webapp/src/client/app/common/directives/wall/message-show-more/message-show-more.html
+++ b/src/webapp/src/client/app/common/directives/wall/message-show-more/message-show-more.html
@@ -1,8 +1,8 @@
-﻿<div class="post-text-container">
+﻿<div class="post-text-container show-more-message-container">
 	<span ng-if="!hasHashtagify" markdown
-	      ng-bind-html="newMessage"></span>
+	      ng-bind-html="message"></span>
 	<span ng-if="!!hasHashtagify" markdown
-		  ng-bind-html="newMessage" 
+		  ng-bind-html="message" 
 		  hashtagify="tagTermClick($event)"></span>
-	<span class="show-more-container"></span>
 </div>
+<span class="show-more-container"></span>

--- a/src/webapp/src/client/styles/style/modules/_modules-other.less
+++ b/src/webapp/src/client/styles/style/modules/_modules-other.less
@@ -606,6 +606,19 @@ input[type=text]::-ms-clear {
     padding-right: 5px;
 }
 
+.show-more-message-container {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 21;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+.show-more-container > a {
+    display: block;
+    margin: 1rem 0;
+ }
+
 .message-box {
     word-wrap: break-word;
     overflow: auto;
@@ -699,11 +712,6 @@ input[type=text]::-ms-clear {
     cursor: pointer;
     max-width: 100%;
     color: #1e8ac7;
-}
-
-.show-more-link {
-    /*float: right;*/
-    white-space: nowrap;
 }
 
 .comment-link {
@@ -1007,7 +1015,6 @@ div.post-text-container {
 }
 
 .post-list-wrapper {
-    margin-top: 12px;
     margin-bottom: 3px;
     font-size: 13px;
 }


### PR DESCRIPTION
Instead of truncating text after a certain number of symbols, I made use of this CSS, where we specify the number of lines  (```-webkit-line-clamp: 21;```) to show in a given container.
```
.show-more-message-container {
    display: -webkit-box;
    -webkit-box-orient: vertical;
    -webkit-line-clamp: 21;
    overflow: hidden;
    text-overflow: ellipsis;
  }
```