### PR TITLE
Fixed participant reset button bug

### DIFF
--- a/src/webapp/src/client/app/events/content/participants/participants-actions/participants-actions.component.js
+++ b/src/webapp/src/client/app/events/content/participants/participants-actions/participants-actions.component.js
@@ -36,7 +36,9 @@
             eventRepository.resetParticipantList(vm.event.id).then(function() {
                 vm.event.participants = [];
                 vm.event.participantsCount = 0;
-                vm.event.participatingStatus = attendStatus.NotAttending;
+                vm.event.participatingStatus = attendStatus.Idle;
+                vm.event.goingCount = 0;
+
                 if (!!vm.event.options.length) {
                     angular.forEach(vm.event.options, function(option) {
                         option.participants = [];

--- a/src/webapp/src/client/app/events/content/participants/participants.component.js
+++ b/src/webapp/src/client/app/events/content/participants/participants.component.js
@@ -33,7 +33,7 @@
 
         vm.isParticipantsLoading = false;
         vm.isMainParticipantList = true;
-        
+
         vm.eventStatus = eventStatus;
         vm.eventStatusService = eventStatusService;
         vm.participantsTabs = [{
@@ -97,6 +97,10 @@
 
                     vm.event.participantsCount = vm.event.participants.length;
 
+                    if(participant.eventStatus === attendStatus.Attending)
+                    {
+                        vm.event.goingCount -= 1;
+                    }
                 }, function(response) {
                     participant.isLoading = false;
 

--- a/src/webapp/src/client/app/events/content/participants/participants.component.js
+++ b/src/webapp/src/client/app/events/content/participants/participants.component.js
@@ -97,7 +97,7 @@
 
                     vm.event.participantsCount = vm.event.participants.length;
 
-                    if(participant.eventStatus === attendStatus.Attending)
+                    if(participant.attendStatus === attendStatus.Attending)
                     {
                         vm.event.goingCount -= 1;
                     }


### PR DESCRIPTION
Changes:
- Fixed event attendance counts when resetting and expelling participants.
- Fixed join button state after resetting event participants
- After the 'reset list' button is pressed, the 'reset list' and 'export' buttons are no longer present.