### PR TITLE
Replaced rest operators with Object.assign()

### DIFF
--- a/src/api/Shrooms.Contracts/DataTransferObjects/FilterPresets/CreateFilterPresetDto.cs
+++ b/src/api/Shrooms.Contracts/DataTransferObjects/FilterPresets/CreateFilterPresetDto.cs
@@ -1,5 +1,4 @@
-﻿
-namespace Shrooms.Contracts.DataTransferObjects.FilterPresets
+﻿namespace Shrooms.Contracts.DataTransferObjects.FilterPresets
 {
     public class CreateFilterPresetDto : FilterPresetDto
     {

--- a/src/api/Shrooms.DataLayer/Migrations/202201241212379_AddedVacationPageModel.cs
+++ b/src/api/Shrooms.DataLayer/Migrations/202201241212379_AddedVacationPageModel.cs
@@ -22,7 +22,6 @@ namespace Shrooms.DataLayer.Migrations
                 .PrimaryKey(t => t.Id)
                 .ForeignKey("dbo.Organizations", t => t.OrganizationId, cascadeDelete: true)
                 .Index(t => t.OrganizationId);
-            
         }
         
         public override void Down()

--- a/src/api/Shrooms.DataLayer/Migrations/202206091029077_AddedFilterPresetEntityModel.cs
+++ b/src/api/Shrooms.DataLayer/Migrations/202206091029077_AddedFilterPresetEntityModel.cs
@@ -26,7 +26,6 @@ namespace Shrooms.DataLayer.Migrations
                 .PrimaryKey(t => t.Id)
                 .ForeignKey("dbo.Organizations", t => t.OrganizationId, cascadeDelete: true)
                 .Index(t => t.OrganizationId);
-            
         }
         
         public override void Down()

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventListingServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventListingServiceTests.cs
@@ -897,7 +897,6 @@ namespace Shrooms.Premium.Tests.DomainService
                 AttendStatus = 1,
                 Event = new Event
                 {
-
                 },
                 ApplicationUser = new ApplicationUser
                 {
@@ -930,7 +929,6 @@ namespace Shrooms.Premium.Tests.DomainService
                     },
                     Events = new List<Event>
                     {
-
                     }
                 }
             };
@@ -944,7 +942,6 @@ namespace Shrooms.Premium.Tests.DomainService
                 AttendStatus = 1,
                 Event = new Event
                 {
-
                 },
                 ApplicationUser = new ApplicationUser
                 {
@@ -977,7 +974,6 @@ namespace Shrooms.Premium.Tests.DomainService
                     },
                     Events = new List<Event>
                     {
-
                     }
                 }
             };
@@ -991,7 +987,6 @@ namespace Shrooms.Premium.Tests.DomainService
                 AttendStatus = 1,
                 Event = new Event
                 {
-
                 },
                 ApplicationUser = new ApplicationUser
                 {

--- a/src/webapp/src/client/app/common/directives/filter-preset/filter-preset.directive.js
+++ b/src/webapp/src/client/app/common/directives/filter-preset/filter-preset.directive.js
@@ -367,15 +367,13 @@
                 if (preset.isDeleted && !preset.isNew) {
                     presetsToDelete.push(preset.id);
                 } else if (preset.isNew && !preset.isDeleted) {
-                    presetsToCreate.push({
-                        ...preset,
+                    presetsToCreate.push(Object.assign({
                         filters: mapControlFiltersToPresetFilters(preset)
-                    });
+                    }, preset));
                 } else if (isPresetUpdated(i)) {
-                    presetsToUpdate.push({
-                        ...preset,
-                        filters: mapControlFiltersToPresetFilters(preset),
-                    });
+                    presetsToUpdate.push(Object.assign({
+                        filters: mapControlFiltersToPresetFilters(preset)
+                    }, preset))
                 }
             }
 

--- a/src/webapp/src/client/app/common/directives/filter-preset/filter-preset.directive.js
+++ b/src/webapp/src/client/app/common/directives/filter-preset/filter-preset.directive.js
@@ -367,13 +367,13 @@
                 if (preset.isDeleted && !preset.isNew) {
                     presetsToDelete.push(preset.id);
                 } else if (preset.isNew && !preset.isDeleted) {
-                    presetsToCreate.push(Object.assign({
-                        filters: mapControlFiltersToPresetFilters(preset)
-                    }, preset));
+                    preset = Object.assign({}, preset);
+                    preset.filters = mapControlFiltersToPresetFilters(preset);
+                    presetsToCreate.push(preset);
                 } else if (isPresetUpdated(i)) {
-                    presetsToUpdate.push(Object.assign({
-                        filters: mapControlFiltersToPresetFilters(preset)
-                    }, preset))
+                    var filters = mapControlFiltersToPresetFilters(preset);
+                    preset.filters = filters;
+                    presetsToUpdate.push(preset);
                 }
             }
 

--- a/src/webapp/src/client/app/events/event-report-list/event-report-list.controller.js
+++ b/src/webapp/src/client/app/events/event-report-list/event-report-list.controller.js
@@ -31,9 +31,10 @@
         };
 
         vm.filter = eventReportService.getEventReportFilter(
-            filterPageTypes.eventReportList,
-            { name: 'events', type: filterTypes.events },
-            { name: 'offices', type: filterTypes.offices }
+            filterPageTypes.eventReportList, [
+                { name: 'events', type: filterTypes.events },
+                { name: 'offices', type: filterTypes.offices }
+            ]
         );
 
         vm.page = 1;

--- a/src/webapp/src/client/app/events/event-report-list/event-report.service.js
+++ b/src/webapp/src/client/app/events/event-report-list/event-report.service.js
@@ -6,15 +6,14 @@
         .factory('eventReportService', eventReportService);
 
     function eventReportService() {
-        function eventReportFilter(pageType, ...filterTypes) {
+        function eventReportFilter(pageType, filterTypes) {
             function constructObjectWithFilterNames(func, response) {
                 var property = {};
 
                 filterTypes.forEach((filter) => {
-                    property = {
-                        ...property,
-                        [filter.name]: func(response, filter),
-                    };
+                    property = Object.assign({
+                        [filter.name]: func(response, filter)
+                    }, property);
                 });
 
                 return property;
@@ -54,11 +53,10 @@
 
             this.pageType = pageType;
 
-            this.appliedFilters = {
-                ...this.appliedFilters,
+            this.appliedFilters = Object.assign({
                 sortBy: undefined,
-                sortOrder: undefined,
-            };
+                sortOrder: undefined
+            }, this.appliedFilters);
 
             this.setFilterTypes = function (response) {
                 this.filterTypes = constructObjectWithFilterNames(
@@ -93,7 +91,7 @@
         }
 
         return {
-            getEventReportFilter: function (pageType, ...filterTypes) {
+            getEventReportFilter: function (pageType, filterTypes) {
                 return new eventReportFilter(pageType, filterTypes);
             },
         };

--- a/src/webapp/src/client/app/events/event-report-list/event-report/event-report.controller.js
+++ b/src/webapp/src/client/app/events/event-report-list/event-report/event-report.controller.js
@@ -38,9 +38,10 @@
         };
 
         vm.filter = eventReportService.getEventReportFilter(
-            filterPageTypes.eventReport,
-            { name: 'events', type: filterTypes.events },
-            { name: 'kudos', type: filterTypes.kudos }
+            filterPageTypes.eventReport, [
+                { name: 'events', type: filterTypes.events },
+                { name: 'kudos', type: filterTypes.kudos }
+            ]
         );
 
         vm.visitedEventsPreviewCount = visitedEventsPreviewCount;
@@ -105,11 +106,10 @@
                                     vm.showActionsColumn = true;
                                 }
 
-                                return {
-                                    ...element,
+                                return Object.assign({
                                     canBeExpanded: canBeExpanded,
                                     isExpanded: false,
-                                };
+                                }, element);
                             });
 
                         vm.isLoading.participants = false;


### PR DESCRIPTION
gulp-ng-annotate does not support rest operators e.g. **...value** (for objects). I replaced them with Object.assign(), however they do not work exactly like rest operators and so I could not use them exactly the same way.