### PR TITLE
Fixed button styling in event reports

### DIFF
--- a/src/webapp/src/client/styles/style/modules/_modules-other.less
+++ b/src/webapp/src/client/styles/style/modules/_modules-other.less
@@ -1591,7 +1591,6 @@ a.disabled.btn, fieldset[disabled] a.btn {
 
     > button {
         width: 100%;
-        display: block;
         height: 48px;
         display: flex;
         align-items: center;


### PR DESCRIPTION
When running locally, the button always had **display: flex;** (which is why I didn't notice duplicate values earlier), but in staging, it has **display: block;**.