### PR TITLE
Fixed 401 in local storage

### DIFF
--- a/src/api/Shrooms.Contracts/Infrastructure/IApplicationSettings.cs
+++ b/src/api/Shrooms.Contracts/Infrastructure/IApplicationSettings.cs
@@ -10,6 +10,8 @@ namespace Shrooms.Contracts.Infrastructure
 
         int DefaultOrganizationId { get; }
 
+        int AccessTokenLifeTimeInHours { get; }
+
         bool IsProductionBuild { get; }
 
         string DemoAccountDefaultPictureId { get; }

--- a/src/api/Shrooms.Infrastructure/Configuration/ApplicationSettings.cs
+++ b/src/api/Shrooms.Infrastructure/Configuration/ApplicationSettings.cs
@@ -14,6 +14,8 @@ namespace Shrooms.Infrastructure.Configuration
 
         public int DefaultOrganizationId => int.Parse(ConfigurationManager.AppSettings["DefaultOrganizationId"]);
 
+        public int AccessTokenLifeTimeInHours => int.Parse(ConfigurationManager.AppSettings["AccessTokenLifeTimeInHours"]);
+
         public bool IsProductionBuild => bool.TryParse(ConfigurationManager.AppSettings["IsProductionBuild"], out var result) && result;
 
         public IEnumerable<string> OAuthRedirectUris => ConfigurationManager.AppSettings["OAuthRedirectUri"].Split(',');

--- a/src/api/Shrooms.Presentation.Api/Controllers/AccountController.cs
+++ b/src/api/Shrooms.Presentation.Api/Controllers/AccountController.cs
@@ -620,8 +620,6 @@ namespace Shrooms.Presentation.Api.Controllers
             var cookieIdentity = await _userManager.CreateIdentityAsync(user, CookieAuthenticationDefaults.AuthenticationType);
             var properties = await CreateInitialRefreshToken(clientId, user, oAuthIdentity);
 
-            SetCookieExpirationDateToAccessTokenLifeTime(properties);
-
             if ((externalLogin.LoginProvider == "Google" && user.GoogleEmail == null) || (externalLogin.LoginProvider == "Facebook" && user.FacebookEmail == null))
             {
                 await _administrationService.AddProviderEmailAsync(user.Id, externalLogin.LoginProvider, externalLogin.Email);

--- a/src/api/Shrooms.Presentation.Api/Controllers/AccountController.cs
+++ b/src/api/Shrooms.Presentation.Api/Controllers/AccountController.cs
@@ -25,6 +25,7 @@ using Shrooms.Domain.Services.Permissions;
 using Shrooms.Domain.Services.RefreshTokens;
 using Shrooms.Presentation.WebViewModels.Models;
 using Shrooms.Presentation.WebViewModels.Models.AccountModels;
+using Shrooms.Contracts.Infrastructure;
 
 namespace Shrooms.Presentation.Api.Controllers
 {
@@ -39,13 +40,20 @@ namespace Shrooms.Presentation.Api.Controllers
         private readonly IOrganizationService _organizationService;
         private readonly IRefreshTokenService _refreshTokenService;
         private readonly IAdministrationUsersService _administrationService;
+        private readonly IApplicationSettings _applicationSettings;
 
         private IAuthenticationManager Authentication => Request.GetOwinContext().Authentication;
 
         private string RequestedOrganization => Request.GetRequestedTenant();
 
-        public AccountController(IMapper mapper, ShroomsUserManager userManager, IPermissionService permissionService,
-            IOrganizationService organizationService, IRefreshTokenService refreshTokenService, IAdministrationUsersService administrationService)
+        public AccountController(
+            IMapper mapper, 
+            ShroomsUserManager userManager, 
+            IPermissionService permissionService,
+            IOrganizationService organizationService, 
+            IRefreshTokenService refreshTokenService, 
+            IAdministrationUsersService administrationService,
+            IApplicationSettings applicationSettings)
         {
             _mapper = mapper;
             _userManager = userManager;
@@ -53,6 +61,7 @@ namespace Shrooms.Presentation.Api.Controllers
             _organizationService = organizationService;
             _refreshTokenService = refreshTokenService;
             _administrationService = administrationService;
+            _applicationSettings = applicationSettings;
         }
 
         [HostAuthentication(DefaultAuthenticationTypes.ExternalBearer)]
@@ -136,8 +145,10 @@ namespace Shrooms.Presentation.Api.Controllers
             Authentication.SignOut(DefaultAuthenticationTypes.ExternalCookie);
             var oAuthIdentity = await _userManager.CreateIdentityAsync(user, OAuthDefaults.AuthenticationType);
             var cookieIdentity = await _userManager.CreateIdentityAsync(user, CookieAuthenticationDefaults.AuthenticationType);
+
             var properties = await CreateInitialRefreshToken(model.ClientId, user, oAuthIdentity);
-            properties.IsPersistent = model.IsPersistance;
+
+            SetCookieExpirationDateToAccessTokenLifeTime(properties);
 
             Authentication.SignIn(properties, oAuthIdentity, cookieIdentity);
 
@@ -609,12 +620,23 @@ namespace Shrooms.Presentation.Api.Controllers
             var cookieIdentity = await _userManager.CreateIdentityAsync(user, CookieAuthenticationDefaults.AuthenticationType);
             var properties = await CreateInitialRefreshToken(clientId, user, oAuthIdentity);
 
+            SetCookieExpirationDateToAccessTokenLifeTime(properties);
+
             if ((externalLogin.LoginProvider == "Google" && user.GoogleEmail == null) || (externalLogin.LoginProvider == "Facebook" && user.FacebookEmail == null))
             {
                 await _administrationService.AddProviderEmailAsync(user.Id, externalLogin.LoginProvider, externalLogin.Email);
             }
 
             Authentication.SignIn(properties, oAuthIdentity, cookieIdentity);
+        }
+
+        private void SetCookieExpirationDateToAccessTokenLifeTime(AuthenticationProperties properties)
+        {
+            // Set the .AspNet.Cookies. expiration date to the same date as the access token lifetime
+            var lifeTimeHoursTimeSpan = TimeSpan.FromHours(Convert.ToInt16(_applicationSettings.AccessTokenLifeTimeInHours));
+            var expirationDate = DateTime.UtcNow.Add(lifeTimeHoursTimeSpan);
+
+            properties.ExpiresUtc = DateTime.SpecifyKind(expirationDate, DateTimeKind.Utc);
         }
     }
 }

--- a/src/api/Shrooms.Presentation.WebViewModels/Models/AccountViewModels.cs
+++ b/src/api/Shrooms.Presentation.WebViewModels/Models/AccountViewModels.cs
@@ -39,9 +39,6 @@ namespace Shrooms.Presentation.WebViewModels.Models
 
         [Required]
         public string ClientId { get; set; }
-
-        [Required]
-        public bool IsPersistance { get; set; }
     }
 
     public class RegisterViewModel

--- a/src/webapp/src/client/app/auth/login/loginAuth.controller.js
+++ b/src/webapp/src/client/app/auth/login/loginAuth.controller.js
@@ -22,7 +22,7 @@
         var vm = this;
         var hashArray = authService.getHashArrayFromUrl();
         var access_token = hashArray['access_token'];
-        var redirect = $location.search().redirect; 
+        var redirect = $location.search().redirect;
 
         vm.organizationName = authService.getOrganizationNameFromUrl() || '';
         vm.endPoint = endPoint;
@@ -37,7 +37,6 @@
 
         vm.email = '';
         vm.password = '';
-        vm.isPersistance = false;
 
         vm.loginProvider = loginProvider;
         vm.providerSignIn = providerSignIn;
@@ -129,13 +128,12 @@
 
             const signInInfo = {
                 username: vm.email,
-                password: vm.password,
-                isPersistance: vm.isPersistance
+                password: vm.password
             };
 
             authService.requestToken(signInInfo).then(function(response) {
                 authService.getUserInfo(response.access_token).then(function(info) {
-                    authService.setAuthenticationData(info, response.access_token);            
+                    authService.setAuthenticationData(info, response.access_token);
                     authService.signIn(signInInfo);
 
                     if (redirect) {
@@ -153,7 +151,7 @@
                     notifySrv.error("applicationUser.emailNotVerified");
                 } else {
                     notifySrv.error("applicationUser.incorrectPasswordOrUserName");
-                }          
+                }
             });
         }
 
@@ -223,7 +221,7 @@
                 returnUrl += ':' + $location.port();
             }
 
-            returnUrl += '/' + vm.organizationName + '/Login';        
+            returnUrl += '/' + vm.organizationName + '/Login';
             if (redirect) returnUrl += '?redirect=' + redirect;
             return returnUrl;
         }

--- a/src/webapp/src/client/app/auth/login/loginAuth.html
+++ b/src/webapp/src/client/app/auth/login/loginAuth.html
@@ -14,7 +14,7 @@
 						translate-attr-placeholder="applicationUser.enterEmailAddress"
 						translate
 						ng-cloak>
-				</div>			
+				</div>
 				<div class="form-group search-group search-group-lg padding-bot-10 required">
 					<input type="password"
 						class="form-control"
@@ -26,14 +26,7 @@
 			</div>
 
 			<div class="row">
-				<div class="col-xs-4 col-xs-offset-2">
-					<div class="checkbox">
-						<label>
-							<input type="checkbox" ng-model="vm.isPersistance"> {{ vm.rememberMe }}
-						</label>
-					</div>
-				</div>
-				<div class="col-xs-4">
+				<div class="col-xs-offset-6 col-xs-4">
 					<button type="button" class="auth-link" ng-click="vm.redirectToForgotPassword()">{{ vm.forgotPassword }}</button>
 				</div>
 			</div>
@@ -45,7 +38,7 @@
 				</button>
 			</div>
 		</form>
-		
+
 		<form name="login-form" ng-submit="vm.providerSignIn()">
 			<div class="col-xs-12" ng-show="vm.isGoogle" >
 				<wave-spinner ng-if="vm.isLoading"></wave-spinner>
@@ -69,17 +62,17 @@
 			</div>
 		</form>
     </div>
-    
+
 	<div class="register-form-placement" ng-if="!vm.isLoggingIn">
 		<div name="register-form" class="register-form-container">
 			<div class="col-xs-12 text-center auth-register-text">
 				<span>{{ vm.newEmployee }}</span><br>
-                <span> 
-					{{ vm.registerWith }} 
+                <span>
+					{{ vm.registerWith }}
 					<button ng-show="vm.isInternal" class="auth-link" ng-click="vm.register()">{{ vm.here }}</button>
 					<span ng-show="vm.isInternal && (vm.isGoogle || vm.isFacebook)">{{ vm.or }}</span>
 					<span ng-show="vm.isGoogle || vm.isFacebook">{{ vm.with }}</span>
-					<button ng-show="vm.isGoogle" class="auth-link" ng-click="vm.providerRegister('GoogleRegistration')">Google</button> 
+					<button ng-show="vm.isGoogle" class="auth-link" ng-click="vm.providerRegister('GoogleRegistration')">Google</button>
 					<span ng-show="vm.isGoogle && vm.isFacebook">{{ vm.or }}</span>
 					<button ng-show="vm.isFacebook" class="auth-link" ng-click="vm.providerRegister('FacebookRegistration')">Facebook</button>
 				</span>


### PR DESCRIPTION
Front-end application receives images with the use of ngSrc directive and using it we are not able to send Bearer tokens that's why in addition to those tokens we also save .AspNet.Cookies cookie that allows us to view images without the use of Bearer token. The problem was that when logging in through internal login (not through a provider, e.g., Google) the expiration date of AspNet.Cookies was set to **Session**, so when we close the browser, we **lose** that cookie (however, the Bearer token is still saved in local storage, and since we don't log in again, we don't receive .AspNet.Cookies again).

What I did was set the cookie expiration date to the same date as the Bearer token expiration date. I also removed the "Remember me" checkbox because it does not work. Regardless of what is selected, it will always behave as if we have pressed "Remember me", because all it did was set the IsPersistence parameter (I also removed that parameter) for the <api>/Account/SignIn() endpoint that only influences cookies (and since we do authentication with the use of Bearer tokens, "Remember me" logic should be implemented differently).