### PR TITLE
Fixed markdown link bug

### DIFF
--- a/src/webapp/src/client/app/common/directives/markdown.directive.js
+++ b/src/webapp/src/client/app/common/directives/markdown.directive.js
@@ -1,22 +1,22 @@
 (function () {
     'use strict';
 
-    angular.module('simoonaApp.Common')
-        .directive('markdown', markdown);
+    angular.module('simoonaApp.Common').directive('markdown', markdown);
 
     function markdown() {
         var directive = {
             restrict: 'A',
             replace: true,
-            link: linkFunc
+            link: linkFunc,
         };
-        return directive;
-        function linkFunc (scope, element, attrs) {
 
-            scope.$evalAsync(function() {
+        return directive;
+
+        function linkFunc(scope, element, attrs) {
+            scope.$evalAsync(function () {
                 let text = convertMarkdownToHtml(element[0].innerHTML);
                 element[0].innerHTML = formatMentions(text);
-            })
+            });
 
             function convertMarkdownToHtml(input) {
                 const converterInput = input.replace('&gt;', '>'); // Sanitizer encodes this, needed for blockquote.
@@ -37,28 +37,74 @@
                     'simpleLineBreaks',
                     'simplifiedAutoLink',
                     'strikethrough',
-                    'underline'
+                    'underline',
                 ];
-                enabledFeatures.forEach(option => converter.setOption(option, true));
+
+                enabledFeatures.forEach((option) =>
+                    converter.setOption(option, true)
+                );
             }
 
-            function formatMentions(text) {
+            function formatMentions(htmlText) {
+                var markedObject = getMarkedTextObject(htmlText);
+
                 var pattern = /\B@[\u00BF-\u1FFF\u2C00-\uD7FF\w]+/gi;
-                var matches = text.match(pattern);
-                
+                var matches = markedObject.text.match(pattern);
+
                 if (matches) {
                     matches = matches.filter(onlyUnique);
-                    
-                    matches.forEach(function(cur) {
-                        text = text.split(cur).join(`<strong>${cur}</strong>`);
+
+                    matches.forEach(function (cur) {
+                        markedObject.text = markedObject.text
+                            .split(cur)
+                            .join(`<strong>${cur}</strong>`);
                     });
                 }
 
-                return text;
+                return getUnmarkedText(markedObject);
             }
 
-            function onlyUnique(value, index, self) { 
+            function onlyUnique(value, index, self) {
                 return self.indexOf(value) === index;
+            }
+
+            function getMarkedTextObject(htmlText) {
+                var uniqueMark = `<${new Date().getTime()}>`;
+                var parser = new DOMParser();
+
+                var documentObject = parser.parseFromString(
+                    htmlText,
+                    'text/html'
+                );
+                var documentBody = documentObject.querySelector('body');
+
+                var allLinks = documentBody.querySelectorAll('a');
+
+                var markedText = htmlText;
+
+                for (var link of allLinks) {
+                    markedText = markedText.replace(
+                        link.parentNode.innerHTML,
+                        uniqueMark
+                    );
+                }
+
+                return {
+                    text: markedText,
+                    links: allLinks,
+                    mark: uniqueMark,
+                };
+            }
+
+            function getUnmarkedText(markedObject) {
+                for (var link of markedObject.links) {
+                    markedObject.text = markedObject.text.replace(
+                        markedObject.mark,
+                        link.parentNode.innerHTML
+                    );
+                }
+
+                return markedObject.text;
             }
         }
     }


### PR DESCRIPTION
Updated **formatMentions()** function to hide all **\<a\>** elements (by replacing them with semi-unique marks) before applying formatting. After mentions are formatted, hidden **\<a\>** elements are put back into place.