### PR TITLE
Fixed incorrect permission usage in events

### DIFF
--- a/src/api/Shrooms.Contracts/Constants/AdministrationPermissions.cs
+++ b/src/api/Shrooms.Contracts/Constants/AdministrationPermissions.cs
@@ -26,7 +26,6 @@
         public const string Project = "PROJECT_ADMINISTRATION";
         public const string Monitor = "MONITOR_ADMINISTRATION";
         public const string Wall = "WALL_ADMINISTRATION";
-        public const string EventWall = "EVENTWALL_ADMINISTRATION";
         public const string Lottery = "LOTTERY_ADMINISTRATION";
         public const string Blacklist = "BLACKLIST_ADMINISTRATION";
 

--- a/src/api/Shrooms.Contracts/Constants/BasicPermissions.cs
+++ b/src/api/Shrooms.Contracts/Constants/BasicPermissions.cs
@@ -35,7 +35,6 @@
         public const string Wall = "WALL_BASIC";
 
         public const string Event = "EVENT_BASIC";
-        public const string EventWall = "EVENTWALL_BASIC";
         public const string EventUsers = "EVENTUSERS_BASIC";
         public const string Blacklist = "BLACKLIST_BASIC";
 

--- a/src/api/Shrooms.DataLayer.EntityModels/Models/ImageCollection.cs
+++ b/src/api/Shrooms.DataLayer.EntityModels/Models/ImageCollection.cs
@@ -52,6 +52,11 @@ namespace Shrooms.DataLayer.EntityModels.Models
 
         private void AddImages(IEnumerable<string> images)
         {
+            if (images == null)
+            {
+                return;
+            }
+
             foreach (var image in images)
             {
                 if (string.IsNullOrEmpty(image))

--- a/src/api/Shrooms.DataLayer/Migrations/DataInitializer/PermissionInitializer.cs
+++ b/src/api/Shrooms.DataLayer/Migrations/DataInitializer/PermissionInitializer.cs
@@ -38,7 +38,6 @@ namespace Shrooms.DataLayer.Migrations.DataInitializer
                 .AddBasicPermission(permissionName: BasicPermissions.OfficeUsers, withRoleNames: Roles.NewUser)
                 
                 .AddBasicPermission(permissionName: BasicPermissions.Event, withRoleNames: new[] { Roles.External, Roles.Intern })
-                .AddBasicPermission(permissionName: BasicPermissions.EventWall, withRoleNames: new[] { Roles.External, Roles.Intern })
                 .AddBasicPermission(permissionName: BasicPermissions.EventUsers, withRoleNames: Roles.NewUser)
                 
                 .AddBasicPermission(permissionName: BasicPermissions.Picture, withRoleNames: Roles.NewUser)

--- a/src/api/Shrooms.DataLayer/Migrations/DataInitializer/PermissionInitializer.cs
+++ b/src/api/Shrooms.DataLayer/Migrations/DataInitializer/PermissionInitializer.cs
@@ -72,7 +72,6 @@ namespace Shrooms.DataLayer.Migrations.DataInitializer
                 .AddAdminPermission(permissionName: AdministrationPermissions.QualificationLevel, withRoleNames: Roles.Administration)
 
                 .AddAdminPermission(permissionName: AdministrationPermissions.Event, withRoleNames: new[] { Roles.Administration, Roles.EventsManagement })
-                .AddAdminPermission(permissionName: AdministrationPermissions.EventWall, withRoleNames: Roles.Administration)
 
                 .AddAdminPermission(permissionName: AdministrationPermissions.Vacation, withRoleNames: new[] { Roles.Accountant, Roles.Administration }, module: Modules.Vacation)
                 .AddAdminPermission(permissionName: AdministrationPermissions.Committees, withRoleNames: new[] { Roles.Administration, Roles.KudosAdmin })

--- a/src/api/Shrooms.Domain.ServiceValidators/Validators/Wall/WallValidator.cs
+++ b/src/api/Shrooms.Domain.ServiceValidators/Validators/Wall/WallValidator.cs
@@ -11,7 +11,6 @@ namespace Shrooms.Domain.ServiceValidators.Validators.Wall
     public class WallValidator : IWallValidator
     {
         private readonly IDbSet<WallMember> _wallUsersDbSet;
-
         public WallValidator(IUnitOfWork2 uow)
         {
             _wallUsersDbSet = uow.GetDbSet<WallMember>();

--- a/src/api/Shrooms.Domain/Services/Wall/IWallService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/IWallService.cs
@@ -48,5 +48,13 @@ namespace Shrooms.Domain.Services.Wall
         Task RemoveMemberFromWallsAsync(string userId, List<int> wallIds);
 
         Task ReplaceMembersInWallAsync(IEnumerable<ApplicationUser> newMembers, int wallId, string currentUserId);
+        
+        Task CheckIfUserIsAllowedToModifyWallContentAsync(
+            int wallId,
+            string createdBy,
+            WallType wallType,
+            string defaultPermission,
+            string eventPermission,
+            UserAndOrganizationDto userOrg);
     }
 }

--- a/src/api/Shrooms.Domain/Services/Wall/IWallService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/IWallService.cs
@@ -55,6 +55,6 @@ namespace Shrooms.Domain.Services.Wall
             string createdBy,
             string permission,
             UserAndOrganizationDto userOrg,
-            bool checkForAdministrationEvent = true);
+            bool checkForAdministrationEventPermission = true);
     }
 }

--- a/src/api/Shrooms.Domain/Services/Wall/IWallService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/IWallService.cs
@@ -6,6 +6,7 @@ using Shrooms.Contracts.DataTransferObjects.Wall;
 using Shrooms.Contracts.DataTransferObjects.Wall.Posts;
 using Shrooms.Contracts.Enums;
 using Shrooms.DataLayer.EntityModels.Models;
+using MultiwallWall = Shrooms.DataLayer.EntityModels.Models.Multiwall.Wall;
 
 namespace Shrooms.Domain.Services.Wall
 {
@@ -50,11 +51,10 @@ namespace Shrooms.Domain.Services.Wall
         Task ReplaceMembersInWallAsync(IEnumerable<ApplicationUser> newMembers, int wallId, string currentUserId);
         
         Task CheckIfUserIsAllowedToModifyWallContentAsync(
-            int wallId,
+            MultiwallWall wall,
             string createdBy,
-            WallType wallType,
-            string defaultPermission,
-            string eventPermission,
-            UserAndOrganizationDto userOrg);
+            string permission,
+            UserAndOrganizationDto userOrg,
+            bool checkForAdministrationEvent = true);
     }
 }

--- a/src/api/Shrooms.Domain/Services/Wall/Posts/Comments/CommentService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/Posts/Comments/CommentService.cs
@@ -54,12 +54,11 @@ namespace Shrooms.Domain.Services.Wall.Posts.Comments
             }
 
             await _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
-                comment.Post.WallId,
+                comment.Post.Wall,
                 comment.AuthorId,
-                comment.Post.Wall.Type,
                 BasicPermissions.Comment,
-                BasicPermissions.Event,
-                userOrg);
+                userOrg,
+                checkForAdministrationEvent: false);
 
             var like = comment.Likes.FirstOrDefault(x => x.UserId == userOrg.UserId);
 
@@ -156,12 +155,11 @@ namespace Shrooms.Domain.Services.Wall.Posts.Comments
             }
 
             await _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
-                comment.Post.Wall.Id,
+                comment.Post.Wall,
                 comment.CreatedBy,
-                comment.Post.Wall.Type,
                 AdministrationPermissions.Post,
-                AdministrationPermissions.Event,
-                commentDto);
+                userOrg: commentDto,
+                checkForAdministrationEvent: true);
 
             comment.MessageBody = commentDto.MessageBody;
             comment.Images = new ImageCollection(commentDto.Images);
@@ -182,14 +180,13 @@ namespace Shrooms.Domain.Services.Wall.Posts.Comments
             {
                 throw new ValidationException(ErrorCodes.ContentDoesNotExist, "Comment does not exist");
             }
-       
+
             await _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
-                comment.Post.Wall.Id,
+                comment.Post.Wall,
                 comment.CreatedBy,
-                comment.Post.Wall.Type,
                 AdministrationPermissions.Post,
-                AdministrationPermissions.Event,
-                userOrg);
+                userOrg,
+                checkForAdministrationEvent: true);
 
             _commentsDbSet.Remove(comment);
 
@@ -213,12 +210,11 @@ namespace Shrooms.Domain.Services.Wall.Posts.Comments
             }
 
             await _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
-                comment.Post.Wall.Id,
+                comment.Post.Wall,
                 comment.CreatedBy,
-                comment.Post.Wall.Type,
                 AdministrationPermissions.Post,
-                AdministrationPermissions.Event,
-                userOrg);
+                userOrg,
+                checkForAdministrationEvent: true);
 
             comment.IsHidden = true;
             comment.LastEdit = DateTime.UtcNow;

--- a/src/api/Shrooms.Domain/Services/Wall/Posts/Comments/CommentService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/Posts/Comments/CommentService.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Shrooms.Contracts.Constants;
 using Shrooms.Contracts.DAL;
 using Shrooms.Contracts.DataTransferObjects;
-using Shrooms.Contracts.DataTransferObjects.Wall.Comments;
 using Shrooms.Contracts.DataTransferObjects.Wall.Likes;
 using Shrooms.Contracts.Exceptions;
 using Shrooms.Contracts.Infrastructure;

--- a/src/api/Shrooms.Domain/Services/Wall/Posts/Comments/CommentService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/Posts/Comments/CommentService.cs
@@ -58,7 +58,7 @@ namespace Shrooms.Domain.Services.Wall.Posts.Comments
                 comment.AuthorId,
                 BasicPermissions.Comment,
                 userOrg,
-                checkForAdministrationEvent: false);
+                checkForAdministrationEventPermission: false);
 
             var like = comment.Likes.FirstOrDefault(x => x.UserId == userOrg.UserId);
 
@@ -159,7 +159,7 @@ namespace Shrooms.Domain.Services.Wall.Posts.Comments
                 comment.CreatedBy,
                 AdministrationPermissions.Post,
                 userOrg: commentDto,
-                checkForAdministrationEvent: true);
+                checkForAdministrationEventPermission: true);
 
             comment.MessageBody = commentDto.MessageBody;
             comment.Images = new ImageCollection(commentDto.Images);
@@ -186,7 +186,7 @@ namespace Shrooms.Domain.Services.Wall.Posts.Comments
                 comment.CreatedBy,
                 AdministrationPermissions.Post,
                 userOrg,
-                checkForAdministrationEvent: true);
+                checkForAdministrationEventPermission: true);
 
             _commentsDbSet.Remove(comment);
 
@@ -214,7 +214,7 @@ namespace Shrooms.Domain.Services.Wall.Posts.Comments
                 comment.CreatedBy,
                 AdministrationPermissions.Post,
                 userOrg,
-                checkForAdministrationEvent: true);
+                checkForAdministrationEventPermission: true);
 
             comment.IsHidden = true;
             comment.LastEdit = DateTime.UtcNow;

--- a/src/api/Shrooms.Domain/Services/Wall/Posts/PostService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/Posts/PostService.cs
@@ -126,7 +126,7 @@ namespace Shrooms.Domain.Services.Wall.Posts
                     post.AuthorId,
                     BasicPermissions.Post,
                     userOrg,
-                    checkForAdministrationEvent: false);
+                    checkForAdministrationEventPermission: false);
 
                 var like = post.Likes.FirstOrDefault(x => x.UserId == userOrg.UserId);
                 if (like == null)
@@ -168,7 +168,7 @@ namespace Shrooms.Domain.Services.Wall.Posts
                     post.CreatedBy,
                     AdministrationPermissions.Post,
                     userOrg: editPostDto,
-                    checkForAdministrationEvent: true);
+                    checkForAdministrationEventPermission: true);
 
                 post.MessageBody = editPostDto.MessageBody;
                 post.Images = new ImageCollection(editPostDto.Images);
@@ -209,7 +209,7 @@ namespace Shrooms.Domain.Services.Wall.Posts
                     post.CreatedBy,
                     AdministrationPermissions.Post,
                     userOrg,
-                    checkForAdministrationEvent: true);
+                    checkForAdministrationEventPermission: true);
 
                 await _commentService.DeleteCommentsByPostAsync(post.Id);
                 _postsDbSet.Remove(post);
@@ -242,7 +242,7 @@ namespace Shrooms.Domain.Services.Wall.Posts
                     post.CreatedBy,
                     AdministrationPermissions.Post,
                     userOrg,
-                    checkForAdministrationEvent: true);
+                    checkForAdministrationEventPermission: true);
 
                 post.IsHidden = true;
                 post.LastEdit = DateTime.UtcNow;

--- a/src/api/Shrooms.Domain/Services/Wall/Posts/PostService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/Posts/PostService.cs
@@ -29,6 +29,7 @@ namespace Shrooms.Domain.Services.Wall.Posts
 
         private readonly IPermissionService _permissionService;
         private readonly ICommentService _commentService;
+        private readonly IWallService _wallService;
 
         private readonly IUnitOfWork2 _uow;
         private readonly IDbSet<Post> _postsDbSet;
@@ -37,11 +38,16 @@ namespace Shrooms.Domain.Services.Wall.Posts
         private readonly IDbSet<DataLayer.EntityModels.Models.Multiwall.Wall> _wallsDbSet;
         private readonly DbSet<PostWatcher> _postWatchers;
 
-        public PostService(IUnitOfWork2 uow, IPermissionService permissionService, ICommentService commentService)
+        public PostService(
+            IUnitOfWork2 uow,
+            IPermissionService permissionService,
+            ICommentService commentService,
+            IWallService wallService)
         {
             _uow = uow;
             _permissionService = permissionService;
             _commentService = commentService;
+            _wallService = wallService;
 
             _postsDbSet = uow.GetDbSet<Post>();
             _usersDbSet = uow.GetDbSet<ApplicationUser>();
@@ -115,6 +121,14 @@ namespace Shrooms.Domain.Services.Wall.Posts
                     throw new ValidationException(ErrorCodes.ContentDoesNotExist, "Post does not exist");
                 }
 
+                await _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
+                    post.WallId,
+                    post.AuthorId,
+                    post.Wall.Type,
+                    BasicPermissions.Post,
+                    BasicPermissions.Event,
+                    userOrg);
+
                 var like = post.Likes.FirstOrDefault(x => x.UserId == userOrg.UserId);
                 if (like == null)
                 {
@@ -150,13 +164,13 @@ namespace Shrooms.Domain.Services.Wall.Posts
                     throw new ValidationException(ErrorCodes.ContentDoesNotExist, "Post not found");
                 }
 
-                var isWallModerator = await _moderatorsDbSet.AnyAsync(x => x.UserId == editPostDto.UserId && x.WallId == post.WallId) || post.CreatedBy == editPostDto.UserId;
-                var isAdministrator = await _permissionService.UserHasPermissionAsync(editPostDto, AdministrationPermissions.Post);
-
-                if (!isAdministrator && !isWallModerator)
-                {
-                    throw new UnauthorizedException();
-                }
+                await _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
+                    post.WallId,
+                    post.CreatedBy,
+                    post.Wall.Type,
+                    AdministrationPermissions.Post,
+                    AdministrationPermissions.Event,
+                    editPostDto);
 
                 post.MessageBody = editPostDto.MessageBody;
                 post.Images = new ImageCollection(editPostDto.Images);
@@ -192,14 +206,13 @@ namespace Shrooms.Domain.Services.Wall.Posts
                     throw new ValidationException(ErrorCodes.ContentDoesNotExist, "Post not found");
                 }
 
-                var isWallModerator = await _moderatorsDbSet
-                    .AnyAsync(x => x.UserId == userOrg.UserId && x.WallId == post.WallId);
-
-                var isAdministrator = await _permissionService.UserHasPermissionAsync(userOrg, AdministrationPermissions.Post);
-                if (!isAdministrator && !isWallModerator)
-                {
-                    throw new UnauthorizedException();
-                }
+                await _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
+                    post.WallId,
+                    post.CreatedBy,
+                    post.Wall.Type,
+                    AdministrationPermissions.Post,
+                    AdministrationPermissions.Event,
+                    userOrg);
 
                 await _commentService.DeleteCommentsByPostAsync(post.Id);
                 _postsDbSet.Remove(post);
@@ -227,14 +240,13 @@ namespace Shrooms.Domain.Services.Wall.Posts
                     throw new ValidationException(ErrorCodes.ContentDoesNotExist, "Post not found");
                 }
 
-                var isWallModerator = await _moderatorsDbSet
-                    .AnyAsync(x => x.UserId == userOrg.UserId && x.WallId == post.WallId) || post.AuthorId == userOrg.UserId;
-
-                var isAdministrator = await _permissionService.UserHasPermissionAsync(userOrg, AdministrationPermissions.Post);
-                if (!isAdministrator && !isWallModerator)
-                {
-                    throw new UnauthorizedException();
-                }
+                await _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
+                    post.WallId,
+                    post.CreatedBy,
+                    post.Wall.Type,
+                    AdministrationPermissions.Post,
+                    AdministrationPermissions.Event,
+                    userOrg);
 
                 post.IsHidden = true;
                 post.LastEdit = DateTime.UtcNow;

--- a/src/api/Shrooms.Domain/Services/Wall/Posts/PostService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/Posts/PostService.cs
@@ -122,12 +122,11 @@ namespace Shrooms.Domain.Services.Wall.Posts
                 }
 
                 await _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
-                    post.WallId,
+                    post.Wall,
                     post.AuthorId,
-                    post.Wall.Type,
                     BasicPermissions.Post,
-                    BasicPermissions.Event,
-                    userOrg);
+                    userOrg,
+                    checkForAdministrationEvent: false);
 
                 var like = post.Likes.FirstOrDefault(x => x.UserId == userOrg.UserId);
                 if (like == null)
@@ -165,12 +164,11 @@ namespace Shrooms.Domain.Services.Wall.Posts
                 }
 
                 await _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
-                    post.WallId,
+                    post.Wall,
                     post.CreatedBy,
-                    post.Wall.Type,
                     AdministrationPermissions.Post,
-                    AdministrationPermissions.Event,
-                    editPostDto);
+                    userOrg: editPostDto,
+                    checkForAdministrationEvent: true);
 
                 post.MessageBody = editPostDto.MessageBody;
                 post.Images = new ImageCollection(editPostDto.Images);
@@ -207,12 +205,11 @@ namespace Shrooms.Domain.Services.Wall.Posts
                 }
 
                 await _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
-                    post.WallId,
+                    post.Wall,
                     post.CreatedBy,
-                    post.Wall.Type,
                     AdministrationPermissions.Post,
-                    AdministrationPermissions.Event,
-                    userOrg);
+                    userOrg,
+                    checkForAdministrationEvent: true);
 
                 await _commentService.DeleteCommentsByPostAsync(post.Id);
                 _postsDbSet.Remove(post);
@@ -241,12 +238,11 @@ namespace Shrooms.Domain.Services.Wall.Posts
                 }
 
                 await _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
-                    post.WallId,
+                    post.Wall,
                     post.CreatedBy,
-                    post.Wall.Type,
                     AdministrationPermissions.Post,
-                    AdministrationPermissions.Event,
-                    userOrg);
+                    userOrg,
+                    checkForAdministrationEvent: true);
 
                 post.IsHidden = true;
                 post.LastEdit = DateTime.UtcNow;

--- a/src/api/Shrooms.Domain/Services/Wall/WallService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/WallService.cs
@@ -119,7 +119,10 @@ namespace Shrooms.Domain.Services.Wall
                 throw new ValidationException(ErrorCodes.ContentDoesNotExist, "Wall not found");
             }
 
-            var isWallAdmin = await _permissionService.UserHasPermissionAsync(updateWallDto, AdministrationPermissions.Wall);
+            var isWallAdmin = wall.Type != WallType.Events ?
+                await _permissionService.UserHasPermissionAsync(updateWallDto, AdministrationPermissions.Wall) :
+                await _permissionService.UserHasPermissionAsync(updateWallDto, AdministrationPermissions.Event);
+
             var isModerator = wall.Moderators.Any(m => m.UserId == updateWallDto.UserId);
 
             if (!isWallAdmin && !isModerator)
@@ -459,6 +462,7 @@ namespace Shrooms.Domain.Services.Wall
             await AddMemberToWallsAsync(responsibleUserId, new List<int> { wallId });
 
             _moderatorsDbSet.Add(newModerator);
+
             await _uow.SaveChangesAsync(userId.UserId);
         }
 

--- a/src/api/Shrooms.Domain/Services/Wall/WallService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/WallService.cs
@@ -405,15 +405,10 @@ namespace Shrooms.Domain.Services.Wall
                 throw new ValidationException(ErrorCodes.ContentDoesNotExist);
             }
 
-            var hasPermission = await _permissionService.UserHasPermissionAsync(userOrg, AdministrationPermissions.Wall);
-
-            var isWallModerator = wall.Moderators.Any(x => x.UserId == userOrg.UserId) || hasPermission;
-            if (!isWallModerator)
-            {
-                throw new UnauthorizedException();
-            }
+            await CheckIfUserIsAllowedToModifyWallContentAsync(wall, userOrg);
 
             _wallsDbSet.Remove(wall);
+
             await _uow.SaveChangesAsync(userOrg.UserId);
         }
 

--- a/src/api/Shrooms.Domain/Services/Wall/WallService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/WallService.cs
@@ -582,7 +582,7 @@ namespace Shrooms.Domain.Services.Wall
             string createdBy,
             string permission,
             UserAndOrganizationDto userOrg,
-            bool checkForAdministrationEvent = true)
+            bool checkForAdministrationEventPermission = true)
         {
             var isModerator = createdBy == userOrg.UserId || await _moderatorsDbSet
                 .AnyAsync(moderator =>
@@ -594,7 +594,7 @@ namespace Shrooms.Domain.Services.Wall
                 isModerator,
                 permission,
                 userOrg,
-                checkForAdministrationEvent);
+                checkForAdministrationEventPermission);
         }
 
         private async Task CheckIfUserIsAllowedToModifyWallContentAsync(MultiwallWall wall, UserAndOrganizationDto userOrg)
@@ -609,14 +609,14 @@ namespace Shrooms.Domain.Services.Wall
             bool isModerator,
             string permission,
             UserAndOrganizationDto userOrg,
-            bool checkForAdministrationEvent)
+            bool checkForAdministrationEventPermission)
         {
             if (isModerator)
             {
                 return;
             }
 
-            var eventPermission = checkForAdministrationEvent ?
+            var eventPermission = checkForAdministrationEventPermission ?
                 AdministrationPermissions.Event :
                 BasicPermissions.Event;
 

--- a/src/api/Shrooms.Premium/Domain/Services/Events/EventService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/EventService.cs
@@ -202,6 +202,7 @@ namespace Shrooms.Premium.Domain.Services.Events
             _eventValidationService.CheckIfCreatingEventHasInsufficientOptions(eventDto.MaxOptions, totalOptionsProvided);
             _eventValidationService.CheckIfCreatingEventHasNoChoices(eventDto.MaxOptions, totalOptionsProvided);
             _eventValidationService.CheckIfAttendOptionsAllowedToUpdate(eventDto, eventToUpdate);
+
             await ValidateEvent(eventDto);
 
             if (eventDto.ResetParticipantList)
@@ -210,6 +211,7 @@ namespace Shrooms.Premium.Domain.Services.Events
             }
 
             await UpdateWallAsync(eventToUpdate, eventDto);
+
             UpdateEventInfo(eventDto, eventToUpdate);
             UpdateEventOptions(eventDto, eventToUpdate);
 

--- a/src/api/Shrooms.Presentation.Api/Controllers/CommentController.cs
+++ b/src/api/Shrooms.Presentation.Api/Controllers/CommentController.cs
@@ -50,6 +50,11 @@ namespace Shrooms.Presentation.Api.Controllers
 
             var wallPost = await _wallService.GetWallPostAsync(userAndOrg, comment.PostId);
 
+            if (!await _permissionService.UserHasPermissionAsync(userAndOrg, BasicPermissions.Comment) && wallPost.WallType != WallType.Events)
+            {
+                return Forbidden();
+            }
+
             var commentDto = _mapper.Map<NewCommentViewModel, NewCommentDto>(comment);
             SetOrganizationAndUser(commentDto);
             var userHubDto = GetUserAndOrganizationHub();
@@ -71,7 +76,7 @@ namespace Shrooms.Presentation.Api.Controllers
 
         [HttpPut]
         [Route("Edit")]
-        [PermissionAnyOfAuthorize(BasicPermissions.Comment, BasicPermissions.EventWall)]
+        [PermissionAnyOfAuthorize(BasicPermissions.Comment, BasicPermissions.Event)]
         public async Task<IHttpActionResult> EditComment(EditCommentViewModel commentViewModel)
         {
             if (!ModelState.IsValid)
@@ -103,7 +108,7 @@ namespace Shrooms.Presentation.Api.Controllers
 
         [HttpDelete]
         [Route("Delete")]
-        [PermissionAnyOfAuthorize(BasicPermissions.Comment, BasicPermissions.EventWall)]
+        [PermissionAnyOfAuthorize(BasicPermissions.Comment, BasicPermissions.Event)]
         public async Task<IHttpActionResult> DeleteComment(int id)
         {
             if (!ModelState.IsValid)
@@ -128,7 +133,7 @@ namespace Shrooms.Presentation.Api.Controllers
 
         [HttpPut]
         [Route("Hide")]
-        [PermissionAnyOfAuthorize(BasicPermissions.Comment, BasicPermissions.EventWall)]
+        [PermissionAnyOfAuthorize(BasicPermissions.Comment, BasicPermissions.Event)]
         public async Task<IHttpActionResult> HideComment(HideCommentViewModel comment)
         {
             if (!ModelState.IsValid)
@@ -153,7 +158,7 @@ namespace Shrooms.Presentation.Api.Controllers
 
         [HttpPut]
         [Route("Like")]
-        [PermissionAuthorize(Permission = BasicPermissions.Post)]
+        [PermissionAnyOfAuthorize(BasicPermissions.Comment, BasicPermissions.Event)]
         public async Task<IHttpActionResult> ToggleLike(AddLikeViewModel addLikeViewModel)
         {
             if (!ModelState.IsValid)

--- a/src/api/Shrooms.Presentation.Api/Controllers/CommentController.cs
+++ b/src/api/Shrooms.Presentation.Api/Controllers/CommentController.cs
@@ -38,7 +38,7 @@ namespace Shrooms.Presentation.Api.Controllers
 
         [HttpPost]
         [Route("Create")]
-        [PermissionAnyOfAuthorize(BasicPermissions.Comment, BasicPermissions.EventWall)]
+        [PermissionAnyOfAuthorize(BasicPermissions.Comment, BasicPermissions.Event)]
         public async Task<IHttpActionResult> CreateComment(NewCommentViewModel comment)
         {
             if (!ModelState.IsValid)
@@ -49,10 +49,6 @@ namespace Shrooms.Presentation.Api.Controllers
             var userAndOrg = GetUserAndOrganization();
 
             var wallPost = await _wallService.GetWallPostAsync(userAndOrg, comment.PostId);
-            if (!await _permissionService.UserHasPermissionAsync(userAndOrg, BasicPermissions.Comment) && wallPost.WallType != WallType.Events)
-            {
-                return Forbidden();
-            }
 
             var commentDto = _mapper.Map<NewCommentViewModel, NewCommentDto>(comment);
             SetOrganizationAndUser(commentDto);

--- a/src/api/Shrooms.Presentation.Api/Controllers/FilterPresetController.cs
+++ b/src/api/Shrooms.Presentation.Api/Controllers/FilterPresetController.cs
@@ -27,7 +27,7 @@ namespace Shrooms.Presentation.Api.Controllers
 
         [HttpPost]
         [Route("Update")]
-        [PermissionAuthorize(Permission = BasicPermissions.ApplicationUser)]
+        [PermissionAuthorize(Permission = AdministrationPermissions.Event)]
         public async Task<IHttpActionResult> Update(ManageFilterPresetViewModel manageViewModel)
         {
             if (!ModelState.IsValid)
@@ -54,7 +54,7 @@ namespace Shrooms.Presentation.Api.Controllers
 
         [HttpGet]
         [Route("GetPresetsForPage")]
-        [PermissionAuthorize(Permission = BasicPermissions.ApplicationUser)]
+        [PermissionAuthorize(Permission = AdministrationPermissions.Event)]
         public async Task<IHttpActionResult> GetPresets(PageType pageType)
         {
             try
@@ -73,7 +73,7 @@ namespace Shrooms.Presentation.Api.Controllers
 
         [HttpGet]
         [Route("GetFilters")]
-        [PermissionAuthorize(Permission = AdministrationPermissions.Administration)]
+        [PermissionAuthorize(Permission = AdministrationPermissions.Event)]
         public async Task<IHttpActionResult> GetFilters([FromUri] FilterType[] filterTypes)
         {
             try

--- a/src/api/Shrooms.Presentation.Api/Controllers/PostController.cs
+++ b/src/api/Shrooms.Presentation.Api/Controllers/PostController.cs
@@ -40,7 +40,7 @@ namespace Shrooms.Presentation.Api.Controllers
         }
 
         [HttpGet]
-        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.EventWall)]
+        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.Event)]
         public async Task<IHttpActionResult> GetPost(int postId)
         {
             try
@@ -64,7 +64,7 @@ namespace Shrooms.Presentation.Api.Controllers
 
         [HttpPost]
         [Route("Create")]
-        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.EventWall)]
+        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.Event)]
         public async Task<IHttpActionResult> CreatePost(CreateWallPostViewModel wallPostViewModel)
         {
             if (!ModelState.IsValid)
@@ -103,7 +103,7 @@ namespace Shrooms.Presentation.Api.Controllers
 
         [HttpPut]
         [Route("Edit")]
-        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.EventWall)]
+        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.Event)]
         public async Task<IHttpActionResult> EditPost(EditPostViewModel editedPost)
         {
             if (!ModelState.IsValid)
@@ -136,7 +136,7 @@ namespace Shrooms.Presentation.Api.Controllers
 
         [HttpDelete]
         [Route("Delete")]
-        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.EventWall)]
+        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.Event)]
         public async Task<IHttpActionResult> DeletePost(int id)
         {
             if (id <= 0)
@@ -162,7 +162,7 @@ namespace Shrooms.Presentation.Api.Controllers
 
         [HttpPut]
         [Route("Hide")]
-        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.EventWall)]
+        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.Event)]
         public async Task<IHttpActionResult> HidePost(HidePostViewModel post)
         {
             if (!ModelState.IsValid)
@@ -188,7 +188,7 @@ namespace Shrooms.Presentation.Api.Controllers
 
         [HttpPut]
         [Route("Like")]
-        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.EventWall)]
+        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.Event)] // TODO:... make event only work?
         public async Task<IHttpActionResult> ToggleLike(AddLikeViewModel addLikeViewModel)
         {
             if (!ModelState.IsValid)

--- a/src/api/Shrooms.Presentation.Api/Controllers/PostController.cs
+++ b/src/api/Shrooms.Presentation.Api/Controllers/PostController.cs
@@ -188,7 +188,7 @@ namespace Shrooms.Presentation.Api.Controllers
 
         [HttpPut]
         [Route("Like")]
-        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.Event)] // TODO:... make event only work?
+        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.Event)]
         public async Task<IHttpActionResult> ToggleLike(AddLikeViewModel addLikeViewModel)
         {
             if (!ModelState.IsValid)

--- a/src/api/Shrooms.Presentation.Api/Controllers/Wall/WallController.cs
+++ b/src/api/Shrooms.Presentation.Api/Controllers/Wall/WallController.cs
@@ -58,7 +58,7 @@ namespace Shrooms.Presentation.Api.Controllers.Wall
         /// <returns>Wall details in HTTP response</returns>
         [HttpGet]
         [Route("Details")]
-        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.EventWall)]
+        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.Event)]
         public async Task<IHttpActionResult> GetWall(int wallId)
         {
             if (wallId <= 0)
@@ -154,7 +154,7 @@ namespace Shrooms.Presentation.Api.Controllers.Wall
 
         [HttpGet]
         [Route("Posts")]
-        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.EventWall)]
+        [PermissionAnyOfAuthorize(BasicPermissions.Post, BasicPermissions.Event)]
         public async Task<IHttpActionResult> GetPagedWall(int wallId, int page = 1)
         {
             if (wallId <= 0)

--- a/src/api/Shrooms.Tests/DomainService/CommentServiceTests.cs
+++ b/src/api/Shrooms.Tests/DomainService/CommentServiceTests.cs
@@ -251,12 +251,11 @@ namespace Shrooms.Tests.DomainService
             };
 
             _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
-                Arg.Any<int>(),
+                Arg.Any<Wall>(),
                 Arg.Any<string>(),
-                Arg.Any<WallType>(),
                 Arg.Is(AdministrationPermissions.Post),
-                Arg.Is(AdministrationPermissions.Event),
-                Arg.Any<UserAndOrganizationDto>())
+                Arg.Any<UserAndOrganizationDto>(),
+                Arg.Any<bool>())
                 .Returns(Task.FromException(new UnauthorizedException()));
 
             // Act
@@ -341,13 +340,12 @@ namespace Shrooms.Tests.DomainService
             };
 
             _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
-                Arg.Any<int>(),
-                Arg.Any<string>(),
-                Arg.Any<WallType>(),
-                Arg.Is(AdministrationPermissions.Post),
-                Arg.Is(AdministrationPermissions.Event),
-                Arg.Any<UserAndOrganizationDto>())
-                .Returns(Task.FromException(new UnauthorizedException()));
+                  Arg.Any<Wall>(),
+                  Arg.Any<string>(),
+                  Arg.Is(AdministrationPermissions.Post),
+                  Arg.Any<UserAndOrganizationDto>(),
+                  Arg.Any<bool>())
+                  .Returns(Task.FromException(new UnauthorizedException()));
 
             // Assert
             Assert.ThrowsAsync<UnauthorizedException>(async () => await _commentService.DeleteCommentAsync(1, userOrg));

--- a/src/api/Shrooms.Tests/DomainService/CommentServiceTests.cs
+++ b/src/api/Shrooms.Tests/DomainService/CommentServiceTests.cs
@@ -17,6 +17,7 @@ using Shrooms.DataLayer.EntityModels.Models;
 using Shrooms.DataLayer.EntityModels.Models.Multiwall;
 using Shrooms.Domain.Exceptions.Exceptions;
 using Shrooms.Domain.Services.Permissions;
+using Shrooms.Domain.Services.Wall;
 using Shrooms.Domain.Services.Wall.Posts.Comments;
 using Shrooms.Tests.Extensions;
 
@@ -48,7 +49,9 @@ namespace Shrooms.Tests.DomainService
             _systemClock = Substitute.For<ISystemClock>();
             _permissionService = Substitute.For<IPermissionService>();
 
-            _commentService = new CommentService(uow, _systemClock, _permissionService);
+            var wallService = Substitute.For<IWallService>();
+
+            _commentService = new CommentService(uow, _systemClock, _permissionService, wallService);
         }
 
         [Test]

--- a/src/api/Shrooms.Tests/DomainService/PostServiceTests.cs
+++ b/src/api/Shrooms.Tests/DomainService/PostServiceTests.cs
@@ -17,6 +17,7 @@ using Shrooms.DataLayer.EntityModels.Models;
 using Shrooms.DataLayer.EntityModels.Models.Multiwall;
 using Shrooms.Domain.Exceptions.Exceptions;
 using Shrooms.Domain.Services.Permissions;
+using Shrooms.Domain.Services.Wall;
 using Shrooms.Domain.Services.Wall.Posts;
 using Shrooms.Domain.Services.Wall.Posts.Comments;
 using Shrooms.Tests.Extensions;
@@ -46,8 +47,11 @@ namespace Shrooms.Tests.DomainService
             _wallModeratorsDbSet = uow.MockDbSetForAsync<WallModerator>();
 
             _permissionService = Substitute.For<IPermissionService>();
+            
             var commentService = Substitute.For<ICommentService>();
-            _postService = new PostService(uow, _permissionService, commentService);
+            var wallService = Substitute.For<IWallService>();
+
+            _postService = new PostService(uow, _permissionService, commentService, wallService);
         }
 
         [Test]

--- a/src/api/Shrooms.Tests/DomainService/PostServiceTests.cs
+++ b/src/api/Shrooms.Tests/DomainService/PostServiceTests.cs
@@ -230,12 +230,11 @@ namespace Shrooms.Tests.DomainService
             _usersDbSet.SetDbSetDataForAsync(users.AsQueryable());
 
             _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
-                Arg.Any<int>(),
+                Arg.Any<Wall>(),
                 Arg.Any<string>(),
-                Arg.Any<WallType>(),
                 Arg.Is(AdministrationPermissions.Post),
-                Arg.Is(AdministrationPermissions.Event),
-                Arg.Any<UserAndOrganizationDto>())
+                Arg.Any<UserAndOrganizationDto>(),
+                Arg.Any<bool>())
                 .Returns(Task.FromException(new UnauthorizedException()));
 
             Assert.ThrowsAsync<UnauthorizedException>(async () => await _postService.HideWallPostAsync(1, userOrg));
@@ -372,12 +371,11 @@ namespace Shrooms.Tests.DomainService
             };
 
             _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
-                Arg.Any<int>(),
+                Arg.Any<Wall>(),
                 Arg.Any<string>(),
-                Arg.Any<WallType>(),
                 Arg.Is(AdministrationPermissions.Post),
-                Arg.Is(AdministrationPermissions.Event),
-                Arg.Any<UserAndOrganizationDto>())
+                Arg.Any<UserAndOrganizationDto>(),
+                Arg.Any<bool>())
                 .Returns(Task.FromException(new UnauthorizedException()));
 
             // Act
@@ -451,12 +449,11 @@ namespace Shrooms.Tests.DomainService
             };
 
             _wallService.CheckIfUserIsAllowedToModifyWallContentAsync(
-                 Arg.Any<int>(),
+                 Arg.Any<Wall>(),
                  Arg.Any<string>(),
-                 Arg.Any<WallType>(),
                  Arg.Is(AdministrationPermissions.Post),
-                 Arg.Is(AdministrationPermissions.Event),
-                 Arg.Any<UserAndOrganizationDto>())
+                 Arg.Any<UserAndOrganizationDto>(),
+                 Arg.Any<bool>())
                  .Returns(Task.FromException(new UnauthorizedException()));
 
             // Act

--- a/src/webapp/src/client/app/service-request/service-request-description-modal.html
+++ b/src/webapp/src/client/app/service-request/service-request-description-modal.html
@@ -36,7 +36,7 @@
         </li>
         <li class="list-group-item row" ng-if="!!serviceRequest.pictureId" ng-cloak>
             <strong ng-cloak>{{"serviceRequest.image" | translate}}: </strong>
-            <div>
+            <div class="service-request-image-container">
                 <img ng-src="{{serviceRequest.pictureId | thumb}}" ace-picture-modal="serviceRequest.pictureId "/>
             </div>
         </li>

--- a/src/webapp/src/client/resources/en_US/role.json
+++ b/src/webapp/src/client/resources/en_US/role.json
@@ -57,7 +57,6 @@
   "users": "Users",
   "vacations": "Vacations section management",
   "wall": "Walls management",
-  "eventwall": "Events walls management",
   "eventusers": "Events participants list access",
   "external": "External links management",
   "modularization": "Modularization management",

--- a/src/webapp/src/client/resources/lt_LT/role.json
+++ b/src/webapp/src/client/resources/lt_LT/role.json
@@ -57,7 +57,6 @@
   "users": "Vartotojai",
   "vacations": "Atostogų sekcijos valdymas",
   "wall": "Sienų valdymas",
-  "eventwall": "Renginių sienų valdymas",
   "eventusers": "Renginių dalyvių sąrašo prieiga",
   "external": "Išorinių nuorodų valdymas",
   "modularization": "Moduliarizacijos valdymas",


### PR DESCRIPTION
Will need to execute this query before deployment: ```DELETE FROM Permissions WHERE Name = 'EVENTWALL_BASIC' OR Name = 'EVENTWALL_ADMINISTRATION';```