### PR TITLE
Changed EVENTWALL_BASIC occurrences to EVENT_BASIC

### DIFF
--- a/src/webapp/src/client/app/common/directives/wall/posts/post-create/post-create.html
+++ b/src/webapp/src/client/app/common/directives/wall/posts/post-create/post-create.html
@@ -1,4 +1,4 @@
-<div id="wall-post-create" class="panel panel-body" has-one-of-permissions="['POST_BASIC','EVENTWALL_BASIC']">
+<div id="wall-post-create" class="panel panel-body" has-one-of-permissions="['POST_BASIC','EVENT_BASIC']">
 
     <form name="postForm">
 

--- a/src/webapp/src/client/app/common/directives/wall/wall.html
+++ b/src/webapp/src/client/app/common/directives/wall/wall.html
@@ -59,7 +59,7 @@
 
                 <div class="media-body"
                      id="comment-create-anchor-{{$index}}"
-                     has-on-of-permissions="['COMMENT_BASIC','EVENTWALL_BASIC']">
+                     has-on-of-permissions="['COMMENT_BASIC','EVENT_BASIC']">
 
                     <ace-wall-comment-create post="post"
                                              ng-if="!post.isHidden"


### PR DESCRIPTION
Since we have removed EVENTWALL permissions and merged with EVENT, front-end permission checks also had to be updated. However, it does not matter if this PR gets deployed now since, without POST_BASIC permission, the user does not get to view these components at all. (although there could be problems with commenting, but since all users have COMMENT_BASIC permission that should not be a problem)