### PR TITLE
Fix random lotteries not showing up in the list

### DIFF
--- a/src/api/Shrooms.Domain/Extensions/SortableExtensions.cs
+++ b/src/api/Shrooms.Domain/Extensions/SortableExtensions.cs
@@ -9,12 +9,26 @@ namespace Shrooms.Domain.Extensions
     {
         public static ISortable AddSortablePropertiesToStart(this ISortable sortable, params (string, SortDirection)[] sortableProperties)
         {
-            var formattedStrings = sortableProperties.Select(property => $"{property.Item1} {property.Item2.GetString()};");
+            return new Sortable
+            {
+                SortByProperties = $"{SortablePropertiesToOrderString(sortableProperties)}{sortable.SortByProperties}"
+            };
+        }
+
+        public static ISortable AddSortablePropertiesToEnd(this ISortable sortable, params (string, SortDirection)[] sortableProperties)
+        {
+            if (string.IsNullOrEmpty(sortable.SortByProperties))
+            {
+                return AddSortablePropertiesToStart(sortable, sortableProperties);
+            }
 
             return new Sortable
             {
-                SortByProperties = $"{string.Join("", formattedStrings)}{sortable.SortByProperties}"
+                SortByProperties = $"{sortable.SortByProperties};{SortablePropertiesToOrderString(sortableProperties)}"
             };
         }
+
+        private static string SortablePropertiesToOrderString((string, SortDirection)[] sortableProperties) =>
+            string.Join("", sortableProperties.Select(property => $"{property.Item1} {property.Item2.GetString()};"));
     }
 }

--- a/src/api/Shrooms.Premium/Domain/Services/Lotteries/LotteryService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Lotteries/LotteryService.cs
@@ -243,8 +243,8 @@ namespace Shrooms.Premium.Domain.Services.Lotteries
 
         public async Task<IPagedList<LotteryDetailsDto>> GetPagedLotteriesAsync(LotteryListingArgsDto args, UserAndOrganizationDto userOrg)
         {
-            var sortable = args
-                .AddSortablePropertiesToStart((nameof(LotteryDetailsDto.RefundFailed), SortDirection.Descending));
+            var sortable = args.AddSortablePropertiesToStart((nameof(LotteryDetailsDto.RefundFailed), SortDirection.Descending))
+                .AddSortablePropertiesToEnd((nameof(LotteryDetailsDto.Id), SortDirection.Descending));
 
             return await _lotteriesDbSet
                 .Where(lottery => lottery.OrganizationId == userOrg.OrganizationId &&


### PR DESCRIPTION
Added ordering by Id so we would have consistent ordering for all lottery pages. Previously, by default, we sorted by the LotteryDetailsDto.RefundFailed property, which is 0 or 1, meaning that we could not be sure which lotteries would be picked up by this order on other pages.