### PR TITLE
Change email receivers from "to" to "bcc"

### DIFF
--- a/src/api/Shrooms.Infrastructure/Email/MailingService.cs
+++ b/src/api/Shrooms.Infrastructure/Email/MailingService.cs
@@ -105,7 +105,7 @@ namespace Shrooms.Infrastructure.Email
             mailMessage.From = new MailAddress(sender);
             foreach (var receiver in email.Receivers)
             {
-                mailMessage.To.Add(receiver);
+                mailMessage.Bcc.Add(receiver);
             }
 
             if (email.Attachment != null)


### PR DESCRIPTION
Suggestion not to send all emails with receivers as `to` but as `bcc`. By this we can prevent unnecessary user information sharing.