### PR TITLE
Fix event report table settings

### DIFF
--- a/src/api/Shrooms.Premium/Domain/Services/Events/List/EventListingService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/List/EventListingService.cs
@@ -116,8 +116,8 @@ namespace Shrooms.Premium.Domain.Services.Events.List
             }
 
             var events = await query
-                .OrderByPropertyNames(reportArgsDto)
                 .Select(MapEventToReportListEvent())
+                .OrderByPropertyNames(reportArgsDto)
                 .ToPagedListAsync(reportArgsDto.Page, reportArgsDto.PageSize);
 
             SetOfficeValuesForEventReportItems(allOffices, officesCount, events);

--- a/src/webapp/src/client/app/events/event-report-list/event-report-list.html
+++ b/src/webapp/src/client/app/events/event-report-list/event-report-list.html
@@ -89,7 +89,7 @@
                             </th>
                             <th class="hidden-xs hidden-sm">
                                 <ace-sort-multiple-link on-sort="vm.sortByColumn" sort-dir="vm.filter.sortValues.sortOrders[4]"
-                                    sort-field="vm.filter.sortValues.sortBy[4]" position="4" sort-value="eventType.name">
+                                    sort-field="vm.filter.sortValues.sortBy[4]" position="4" sort-value="typeName">
                                     <span translate="events.tableType"></span>
                                 </ace-sort-multiple-link>
                             </th>
@@ -101,7 +101,7 @@
                             </th>
                             <th>
                                 <ace-sort-multiple-link on-sort="vm.sortByColumn" sort-dir="vm.filter.sortValues.sortOrders[6]"
-                                    sort-field="vm.filter.sortValues.sortBy[6]" position="6" sort-value="eventParticipants.Count">
+                                    sort-field="vm.filter.sortValues.sortBy[6]" position="6" sort-value="goingCount">
                                     <span translate="events.tableParticipants"></span>
                                 </ace-sort-multiple-link>
                             </th>

--- a/src/webapp/src/client/app/events/event-report-list/event-report-list.html
+++ b/src/webapp/src/client/app/events/event-report-list/event-report-list.html
@@ -70,37 +70,37 @@
                                 </ace-sort-multiple-link>
                             </th>
                             <th>
-                                <ace-sort-multiple-link on-sort="vm.sortByColumn" sort-dir="vm.filter.sortValues.sortOrders[2]"
-                                    sort-field="vm.filter.sortValues.sortBy[1]" position="1" sort-value="name">
+                                <ace-sort-multiple-link on-sort="vm.sortByColumn" sort-dir="vm.filter.sortValues.sortOrders[1]"
+                                    sort-field="vm.filter.sortValues.sortBy[1]" position="1" sort-value="responsiblePerson">
                                     <span translate="events.responsiblePerson"></span>
                                 </ace-sort-multiple-link>
                             </th>
                             <th class="hidden-xs hidden-sm">
-                                <ace-sort-multiple-link on-sort="vm.sortByColumn" sort-dir="vm.filter.sortValues.sortOrders[3]"
+                                <ace-sort-multiple-link on-sort="vm.sortByColumn" sort-dir="vm.filter.sortValues.sortOrders[2]"
                                     sort-field="vm.filter.sortValues.sortBy[2]" position="2" sort-value="startDate">
                                     <span translate="events.tableStartDate"></span>
                                 </ace-sort-multiple-link>
                             </th>
                             <th class="hidden-xs hidden-sm">
-                                <ace-sort-multiple-link on-sort="vm.sortByColumn" sort-dir="vm.filter.sortValues.sortOrders[4]"
+                                <ace-sort-multiple-link on-sort="vm.sortByColumn" sort-dir="vm.filter.sortValues.sortOrders[3]"
                                     sort-field="vm.filter.sortValues.sortBy[3]" position="3" sort-value="endDate">
                                     <span translate="events.tableEndDate"></span>
                                 </ace-sort-multiple-link>
                             </th>
                             <th class="hidden-xs hidden-sm">
-                                <ace-sort-multiple-link on-sort="vm.sortByColumn" sort-dir="vm.filter.sortValues.sortOrders[5]"
+                                <ace-sort-multiple-link on-sort="vm.sortByColumn" sort-dir="vm.filter.sortValues.sortOrders[4]"
                                     sort-field="vm.filter.sortValues.sortBy[4]" position="4" sort-value="eventType.name">
                                     <span translate="events.tableType"></span>
                                 </ace-sort-multiple-link>
                             </th>
                             <th class="hidden-xs hidden-sm">
-                                <ace-sort-multiple-link on-sort="vm.sortByColumn" sort-dir="vm.filter.sortValues.sortOrders[6]"
+                                <ace-sort-multiple-link on-sort="vm.sortByColumn" sort-dir="vm.filter.sortValues.sortOrders[5]"
                                     sort-field="vm.filter.sortValues.sortBy[5]" position="5" sort-value="offices">
                                     <span translate="events.tableOffices"></span>
                                 </ace-sort-multiple-link>
                             </th>
                             <th>
-                                <ace-sort-multiple-link on-sort="vm.sortByColumn" sort-dir="vm.filter.sortValues.sortOrders[7]"
+                                <ace-sort-multiple-link on-sort="vm.sortByColumn" sort-dir="vm.filter.sortValues.sortOrders[6]"
                                     sort-field="vm.filter.sortValues.sortBy[6]" position="6" sort-value="eventParticipants.Count">
                                     <span translate="events.tableParticipants"></span>
                                 </ace-sort-multiple-link>


### PR DESCRIPTION
After introducing new event search fields sorting didn't work. To make it work with a combination of first name and last name, I changed the sorting to be done by using response type DTO. 