### PR TITLE
Configurable monthly kudos send limit

### DIFF
--- a/src/api/Shrooms.Contracts/Constants/BusinessLayerConstants.cs
+++ b/src/api/Shrooms.Contracts/Constants/BusinessLayerConstants.cs
@@ -30,7 +30,7 @@ namespace Shrooms.Contracts.Constants
         public const string KudosServiceStatusCancelled = "Cancelled";
         public const string KudosStatusAllFilter = "All";
         public const string KudosFilteringTypeAllFilter = "All";
-        public const int KudosAvailableToSendThisMonth = 20;
+        public const int DefaultKudosAvailableToSendPerMonth = 20;
         public const int MaxKudosLogsPerPage = 50;
 
         public const int MaxKudosDescriptionLength = 500;

--- a/src/api/Shrooms.Contracts/Infrastructure/IApplicationSettings.cs
+++ b/src/api/Shrooms.Contracts/Infrastructure/IApplicationSettings.cs
@@ -12,6 +12,8 @@ namespace Shrooms.Contracts.Infrastructure
 
         int AccessTokenLifeTimeInHours { get; }
 
+        int? KudosAvailableToSendPerMonth { get; }
+
         bool IsProductionBuild { get; }
 
         string DemoAccountDefaultPictureId { get; }

--- a/src/api/Shrooms.Infrastructure/Configuration/ApplicationSettings.cs
+++ b/src/api/Shrooms.Infrastructure/Configuration/ApplicationSettings.cs
@@ -16,6 +16,10 @@ namespace Shrooms.Infrastructure.Configuration
 
         public int AccessTokenLifeTimeInHours => int.Parse(ConfigurationManager.AppSettings["AccessTokenLifeTimeInHours"]);
 
+        public int? KudosAvailableToSendPerMonth => ConfigurationManager.AppSettings["KudosAvailableToSendPerMonth"] is { } kudosPerMonth
+            ? int.Parse(kudosPerMonth)
+            : null;
+
         public bool IsProductionBuild => bool.TryParse(ConfigurationManager.AppSettings["IsProductionBuild"], out var result) && result;
 
         public IEnumerable<string> OAuthRedirectUris => ConfigurationManager.AppSettings["OAuthRedirectUri"].Split(',');

--- a/src/api/Shrooms.Presentation.Api/Web.config
+++ b/src/api/Shrooms.Presentation.Api/Web.config
@@ -31,6 +31,7 @@
     <add key="CorsOrigin" value="*" />
     <add key="EmailEnabled" value="true" />
     <add key="DefaultOrganizationId" value="1" />
+    <add key="KudosAvailableToSendPerMonth" value="30" />
     <!--
       External Login Providers Properties
       needed for social logins

--- a/src/api/Shrooms.Presentation.Api/Web.config
+++ b/src/api/Shrooms.Presentation.Api/Web.config
@@ -31,7 +31,7 @@
     <add key="CorsOrigin" value="*" />
     <add key="EmailEnabled" value="true" />
     <add key="DefaultOrganizationId" value="1" />
-    <add key="KudosAvailableToSendPerMonth" value="30" />
+    <add key="KudosAvailableToSendPerMonth" value="20" />
     <!--
       External Login Providers Properties
       needed for social logins

--- a/src/api/Shrooms.Tests/DomainService/KudosServiceTests.cs
+++ b/src/api/Shrooms.Tests/DomainService/KudosServiceTests.cs
@@ -5,7 +5,6 @@ using System.Data.Entity.Infrastructure;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 using System.Web;
 using AutoMapper;
@@ -42,12 +41,15 @@ namespace Shrooms.Tests.DomainService
         private IFilterPresetService _filterPresetService;
         private IUnitOfWork2 _uow;
         private IMapper _mapper;
+        private IApplicationSettings _settings;
 
         [SetUp]
         public void TestInitializer()
         {
             _uow = Substitute.For<IUnitOfWork2>();
             _mapper = ModelMapper.Create();
+            _settings = Substitute.For<IApplicationSettings>();
+            _settings.KudosAvailableToSendPerMonth.Returns((int?)50);
 
             _kudosLogsDbSet = Substitute.For<DbSet<KudosLog>, IQueryable<KudosLog>, IDbAsyncEnumerable<KudosLog>>();
             _kudosLogsDbSet.SetDbSetDataForAsync(MockKudosLogs());
@@ -86,7 +88,8 @@ namespace Shrooms.Tests.DomainService
                 permissionService,
                 kudosServiceValidation,
                 asyncRunner,
-                _filterPresetService);
+                _filterPresetService,
+                _settings);
         }
 
         #region GetKudosLogs
@@ -794,6 +797,7 @@ namespace Shrooms.Tests.DomainService
 
         private IQueryable<KudosLog> MockKudosLogs()
         {
+            int kudosAvailableToSendPerMonth = _settings.KudosAvailableToSendPerMonth ?? BusinessLayerConstants.DefaultKudosAvailableToSendPerMonth;
             var kudosLogs = new List<KudosLog>
             {
                 new KudosLog
@@ -861,9 +865,9 @@ namespace Shrooms.Tests.DomainService
                     },
                     OrganizationId = 2,
                     CreatedBy = "testUserId5",
-                    MultiplyBy = BusinessLayerConstants.KudosAvailableToSendThisMonth - 2,
+                    MultiplyBy = kudosAvailableToSendPerMonth - 2,
                     Created = DateTime.UtcNow,
-                    Points = BusinessLayerConstants.KudosAvailableToSendThisMonth - 2,
+                    Points = kudosAvailableToSendPerMonth - 2,
                     Comments = "Hello"
                 }
             };


### PR DESCRIPTION
Added KudosAvailableToSendPerMonth setting to Web.config - if specified it overrides the default 20.