### PR TITLE
Disable close service request button in the request table when service request is cancelled

### DIFF
--- a/src/webapp/src/client/app/service-request/service-request-table.html
+++ b/src/webapp/src/client/app/service-request/service-request-table.html
@@ -56,12 +56,12 @@
                     <a class="btn btn-primary glyphicon glyphicon-ok" 
                        ng-click="closeKudosServiceRequestButtonClick(serviceRequest)" 
                        title="{{'common.close' | translate}}" 
-                       ng-if="(isAdmin || serviceRequest.isCloseable) && serviceRequest.status.title !== 'Done' && serviceRequest.categoryName === 'Kudos'"></a>
+                       ng-if="(isAdmin || serviceRequest.isCloseable) && !['Done', 'Cancelled'].includes(serviceRequest.status.title) && serviceRequest.categoryName === 'Kudos'"></a>
                     <a class="btn btn-primary glyphicon glyphicon-ok" 
                        ng-click="closeServiceRequestButtonClick(serviceRequest)" 
                        title="{{'common.close' | translate}}" 
-                       ng-if="(isAdmin || serviceRequest.isCloseable) && serviceRequest.status.title !== 'Done' && serviceRequest.categoryName !== 'Kudos'"></a>
-                    <div ng-if="(isAdmin || serviceRequest.isCloseable) && serviceRequest.status.title === 'Done'" style="width: 44px"></div>
+                       ng-if="(isAdmin || serviceRequest.isCloseable) && !['Done', 'Cancelled'].includes(serviceRequest.status.title) && serviceRequest.categoryName !== 'Kudos'"></a>
+                    <div ng-if="(isAdmin || serviceRequest.isCloseable) && ['Done', 'Cancelled'].includes(serviceRequest.status.title)" style="width: 44px"></div>
                     <div ng-if="hasEditableServiceRequests && !serviceRequest.isCloseable" style="width: 44px"></div>
                 </div>
             </td>


### PR DESCRIPTION
Making it not visible for service requests that are in status Cancelled, similiarly how it's done now with completed service requests. 

Before 
![image](https://github.com/VismaLietuva/simoona/assets/31857639/fb7260b9-c8ff-4219-99de-15f72ffc9a02)

After
![image](https://github.com/VismaLietuva/simoona/assets/31857639/d635c5da-3fe9-49dc-8ec0-f851da0463df)
