### PR TITLE
Kudos - expose kudos system type on log type view model

### DIFF
--- a/src/api/Shrooms.Presentation.WebViewModels/Models/Users/Kudos/KudosLogTypeViewModel.cs
+++ b/src/api/Shrooms.Presentation.WebViewModels/Models/Users/Kudos/KudosLogTypeViewModel.cs
@@ -1,5 +1,3 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using Shrooms.Contracts.Enums;
 
 namespace Shrooms.Presentation.WebViewModels.Models.Users.Kudos
@@ -12,7 +10,6 @@ namespace Shrooms.Presentation.WebViewModels.Models.Users.Kudos
 
         public decimal Value { get; set; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
         public KudosTypeEnum Type { get; set; }
     }
 }

--- a/src/api/Shrooms.Presentation.WebViewModels/Models/Users/Kudos/KudosLogTypeViewModel.cs
+++ b/src/api/Shrooms.Presentation.WebViewModels/Models/Users/Kudos/KudosLogTypeViewModel.cs
@@ -1,4 +1,8 @@
-﻿namespace Shrooms.Presentation.WebViewModels.Models.Users.Kudos
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Shrooms.Contracts.Enums;
+
+namespace Shrooms.Presentation.WebViewModels.Models.Users.Kudos
 {
     public class KudosLogTypeViewModel
     {
@@ -7,5 +11,8 @@
         public string Name { get; set; }
 
         public decimal Value { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public KudosTypeEnum Type { get; set; }
     }
 }


### PR DESCRIPTION
The kudos log contains system-generated entries like Minus and Refund, but the API's KudosLogTypeViewModel dropped the KudosTypeEnum classification the service layer already has — so the frontend can't reliably tell a deduction from an award and renders a 5-point deduction as a misleading green +5