### PR TITLE
feat(walls): expose CreatedBy and fix IsHiddenFromAllWalls in wall pa…

### DIFF
--- a/src/api/Shrooms.Contracts.DataTransferObjects/Models/Wall/WallDto.cs
+++ b/src/api/Shrooms.Contracts.DataTransferObjects/Models/Wall/WallDto.cs
@@ -27,5 +27,7 @@ namespace Shrooms.Contracts.DataTransferObjects.Models.Wall
         public int PostsCount { get; set; }
 
         public bool IsWallModerator { get; set; }
+
+        public string CreatedBy { get; set; }
     }
 }

--- a/src/api/Shrooms.Domain/Services/Wall/WallService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/WallService.cs
@@ -194,7 +194,8 @@ namespace Shrooms.Domain.Services.Wall
                     IsFollowing = x.Type == WallType.Main || x.Members.Any(m => m.UserId == userOrg.UserId),
                     Logo = x.Logo,
                     TotalMembers = x.Members.Count,
-                    IsHiddenFromAllWalls = x.IsHiddenFromAllWalls
+                    IsHiddenFromAllWalls = x.IsHiddenFromAllWalls,
+                    CreatedBy = x.CreatedBy
                 })
                 .SingleOrDefaultAsync();
 
@@ -852,7 +853,9 @@ namespace Shrooms.Domain.Services.Wall
                     Type = w.Type,
                     Logo = w.Logo,
                     TotalMembers = w.Members.Count,
-                    PostsCount = w.Posts.Count
+                    PostsCount = w.Posts.Count,
+                    IsHiddenFromAllWalls = w.IsHiddenFromAllWalls,
+                    CreatedBy = w.CreatedBy
                 })
                 .ToListAsync();
 
@@ -874,6 +877,8 @@ namespace Shrooms.Domain.Services.Wall
                     Logo = wall.Logo,
                     TotalMembers = wall.Members.Count,
                     PostsCount = wall.Posts.Count,
+                    IsHiddenFromAllWalls = wall.IsHiddenFromAllWalls,
+                    CreatedBy = wall.CreatedBy,
                     UserId = wallUser.UserId
                 })
                 .Where(x => x.UserId == userOrg.UserId || x.Type == WallType.Main)
@@ -886,7 +891,9 @@ namespace Shrooms.Domain.Services.Wall
                     IsFollowing = true,
                     Logo = x.Logo,
                     TotalMembers = x.TotalMembers,
-                    PostsCount = x.PostsCount
+                    PostsCount = x.PostsCount,
+                    IsHiddenFromAllWalls = x.IsHiddenFromAllWalls,
+                    CreatedBy = x.CreatedBy
                 })
                 .Distinct()
                 .ToListAsync();

--- a/src/api/Shrooms.Presentation.WebViewModels/Models/Wall/WallListViewModel.cs
+++ b/src/api/Shrooms.Presentation.WebViewModels/Models/Wall/WallListViewModel.cs
@@ -30,5 +30,8 @@ namespace Shrooms.Presentation.WebViewModels.Models.Wall
         public int PostsCount { get; set; }
 
         public bool IsWallModerator { get; set; }
+
+        // Wall creators are authorized to modify the wall alongside its moderators.
+        public string CreatedBy { get; set; }
     }
 }

--- a/src/api/Shrooms.Tests/DomainService/WallServiceTests.cs
+++ b/src/api/Shrooms.Tests/DomainService/WallServiceTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using Shrooms.Contracts.Constants;
 using Shrooms.Contracts.DAL;
 using Shrooms.Contracts.DataTransferObjects;
+using Shrooms.Contracts.DataTransferObjects.Models.Wall;
 using Shrooms.Contracts.DataTransferObjects.Wall;
 using Shrooms.Contracts.Enums;
 using Shrooms.Contracts.Exceptions;
@@ -622,6 +623,8 @@ namespace Shrooms.Tests.DomainService
             Assert.That(wall.Description, Is.EqualTo("Description"));
             Assert.That(wall.Logo, Is.EqualTo("Logo.jpg"));
             Assert.That(wall.Type, Is.EqualTo(WallType.UserCreated));
+            Assert.That(wall.IsHiddenFromAllWalls, Is.True);
+            Assert.That(wall.CreatedBy, Is.EqualTo("creator1"));
         }
 
         [Test]
@@ -645,6 +648,55 @@ namespace Shrooms.Tests.DomainService
             Assert.That(wall.Description, Is.EqualTo("Description2"));
             Assert.That(wall.Logo, Is.EqualTo("Logo2.jpg"));
             Assert.That(wall.Type, Is.EqualTo(WallType.UserCreated));
+            Assert.That(wall.IsHiddenFromAllWalls, Is.False);
+            Assert.That(wall.CreatedBy, Is.EqualTo("creator2"));
+        }
+
+        [TestCase(WallsListFilter.All)]
+        [TestCase(WallsListFilter.NotFollowed)]
+        public async Task Should_Populate_IsHiddenFromAllWalls_And_CreatedBy_For_Not_Followed_Walls_List(WallsListFilter filter)
+        {
+            // Arrange
+            MockWallsForList();
+
+            var userOrg = new UserAndOrganizationDto
+            {
+                OrganizationId = 2,
+                UserId = "otherUser"
+            };
+
+            // Act
+            var walls = (await _wallService.GetWallsListAsync(userOrg, filter)).ToList();
+
+            // Assert
+            var hiddenWall = walls.First(w => w.Id == 1);
+            Assert.That(hiddenWall.IsHiddenFromAllWalls, Is.True);
+            Assert.That(hiddenWall.CreatedBy, Is.EqualTo("creator1"));
+
+            var visibleWall = walls.First(w => w.Id == 2);
+            Assert.That(visibleWall.IsHiddenFromAllWalls, Is.False);
+            Assert.That(visibleWall.CreatedBy, Is.EqualTo("creator2"));
+        }
+
+        [Test]
+        public async Task Should_Populate_IsHiddenFromAllWalls_And_CreatedBy_For_Followed_Walls_List()
+        {
+            // Arrange
+            MockWallsForList();
+
+            var userOrg = new UserAndOrganizationDto
+            {
+                OrganizationId = 2,
+                UserId = "member1"
+            };
+
+            // Act
+            var walls = (await _wallService.GetWallsListAsync(userOrg, WallsListFilter.Followed)).ToList();
+
+            // Assert
+            var hiddenWall = walls.First(w => w.Id == 1);
+            Assert.That(hiddenWall.IsHiddenFromAllWalls, Is.True);
+            Assert.That(hiddenWall.CreatedBy, Is.EqualTo("creator1"));
         }
 
         [Test]
@@ -1004,7 +1056,9 @@ namespace Shrooms.Tests.DomainService
                     Description = "Description",
                     Logo = "Logo.jpg",
                     Members = members,
-                    OrganizationId = 2
+                    OrganizationId = 2,
+                    IsHiddenFromAllWalls = true,
+                    CreatedBy = "creator1"
                 },
                 new()
                 {
@@ -1015,7 +1069,9 @@ namespace Shrooms.Tests.DomainService
                     Logo = "Logo2.jpg",
                     Moderators = moderators,
                     Members = members1,
-                    OrganizationId = 2
+                    OrganizationId = 2,
+                    IsHiddenFromAllWalls = false,
+                    CreatedBy = "creator2"
                 }
             };
 
@@ -1041,6 +1097,48 @@ namespace Shrooms.Tests.DomainService
 
             _wallModeratorDbSet.SetDbSetDataForAsync(wallModerators);
             _wallsDbSet.SetDbSetDataForAsync(walls);
+        }
+
+        // Wall 1 is hidden and followed by member1; wall 2 is visible and followed by nobody.
+        private void MockWallsForList()
+        {
+            var wall1Members = new List<WallMember>
+            {
+                new()
+                    { Id = 1, UserId = "member1", WallId = 1 }
+            };
+
+            var walls = new List<Wall>
+            {
+                new()
+                {
+                    Id = 1,
+                    Name = "Hidden wall",
+                    Type = WallType.UserCreated,
+                    OrganizationId = 2,
+                    IsHiddenFromAllWalls = true,
+                    CreatedBy = "creator1",
+                    Members = wall1Members,
+                    Moderators = new List<WallModerator>(),
+                    Posts = new List<Post>()
+                },
+                new()
+                {
+                    Id = 2,
+                    Name = "Visible wall",
+                    Type = WallType.UserCreated,
+                    OrganizationId = 2,
+                    IsHiddenFromAllWalls = false,
+                    CreatedBy = "creator2",
+                    Members = new List<WallMember>(),
+                    Moderators = new List<WallModerator>(),
+                    Posts = new List<Post>()
+                }
+            };
+
+            _wallsDbSet.SetDbSetDataForAsync(walls);
+            _wallUsersDbSet.SetDbSetDataForAsync(wall1Members);
+            _wallModeratorDbSet.SetDbSetDataForAsync(new List<WallModerator>());
         }
 
         private void MockWallsForAddRemoveModerators()


### PR DESCRIPTION
The two wall list projections never assigned IsHiddenFromAllWalls, so /Wall/List reported every wall as visible regardless of its real value. Clients that edited a wall from a list view submitted that false back through /Wall/Edit and silently un-hid the wall.

CreatedBy is now projected too. CheckIfUserIsAllowedToModifyWallContent authorizes wall.CreatedBy alongside moderators, but the field was on no wall payload, so clients could not offer creators the actions the API already grants them.