### PR TITLE
feat(wall): show joined event posts in the followed walls feed

### DIFF
--- a/src/api/Shrooms.Contracts/DataTransferObjects/Wall/Posts/PostDto.cs
+++ b/src/api/Shrooms.Contracts/DataTransferObjects/Wall/Posts/PostDto.cs
@@ -33,6 +33,10 @@ namespace Shrooms.Contracts.DataTransferObjects.Wall.Posts
 
         public WallType WallType { get; set; }
 
+        // Set only for posts on an event wall, so clients can link to the event
+        // instead of the wall (event walls have no wall page).
+        public Guid? EventId { get; set; }
+
         public DateTime LastActivity { get; set; }
 
         public bool CanModerate { get; set; }

--- a/src/api/Shrooms.Contracts/ViewModels/Wall/Posts/WallPostViewModel.cs
+++ b/src/api/Shrooms.Contracts/ViewModels/Wall/Posts/WallPostViewModel.cs
@@ -31,6 +31,9 @@ namespace Shrooms.Contracts.ViewModels.Wall.Posts
 
         public string WallName { get; set; }
 
+        // Non-null only for event wall posts — see PostDto.EventId.
+        public Guid? EventId { get; set; }
+
         public DateTime LastActivity { get; set; }
 
         public bool CanModerate { get; set; }

--- a/src/api/Shrooms.Domain/Services/Wall/WallService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/WallService.cs
@@ -19,6 +19,7 @@ using Shrooms.Contracts.DataTransferObjects.Wall.Posts;
 using Shrooms.Contracts.Enums;
 using Shrooms.Contracts.Exceptions;
 using Shrooms.DataLayer.EntityModels.Models;
+using Shrooms.DataLayer.EntityModels.Models.Events;
 using Shrooms.DataLayer.EntityModels.Models.Multiwall;
 using Shrooms.Domain.Exceptions.Exceptions;
 using Shrooms.Domain.Services.Permissions;
@@ -30,6 +31,10 @@ namespace Shrooms.Domain.Services.Wall
     {
         private static readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
 
+        // How long an event's wall keeps feeding the followed-walls post feed
+        // after the event has ended.
+        private const int EventWallFeedDaysAfterEnd = 7;
+
         private readonly IMapper _mapper;
         private readonly IUnitOfWork2 _uow;
         private readonly IPermissionService _permissionService;
@@ -40,6 +45,7 @@ namespace Shrooms.Domain.Services.Wall
         private readonly DbSet<WallModerator> _moderatorsDbSet;
         private readonly DbSet<MultiwallWall> _wallsDbSet;
         private readonly DbSet<PostWatcher> _postWatchers;
+        private readonly DbSet<Event> _eventsDbSet;
 
         public WallService(IMapper mapper, IUnitOfWork2 uow, IPermissionService permissionService)
         {
@@ -53,6 +59,7 @@ namespace Shrooms.Domain.Services.Wall
             _usersDbSet = uow.GetDbSet<ApplicationUser>();
             _wallsDbSet = uow.GetDbSet<DataLayer.EntityModels.Models.Multiwall.Wall>();
             _postWatchers = uow.GetDbSet<PostWatcher>();
+            _eventsDbSet = uow.GetDbSet<Event>();
         }
 
         public async Task<int> CreateNewWallAsync(CreateWallDto newWallDto)
@@ -693,6 +700,11 @@ namespace Shrooms.Domain.Services.Wall
             else
             {
                 wallsIds = (await GetWallsListAsync(userOrg, wallsListFilter)).Select(w => w.Id).ToList();
+
+                if (wallsListFilter == WallsListFilter.Followed)
+                {
+                    wallsIds.AddRange(await GetRecentEventWallIdsAsync(userOrg));
+                }
             }
 
             var entriesCountToSkip = (pageNumber - 1) * pageSize;
@@ -711,7 +723,62 @@ namespace Shrooms.Domain.Services.Wall
             var watchedPosts = await RetrieveWatchedPostsAsync(userOrg.UserId, posts);
             var users = await GetUsersAsync(posts);
 
-            return MapPostsWithChildEntitiesToDto(userOrg.UserId, posts, users, moderators, watchedPosts);
+            var mappedPosts = MapPostsWithChildEntitiesToDto(userOrg.UserId, posts, users, moderators, watchedPosts).ToList();
+
+            await AssignEventIdsAsync(mappedPosts);
+
+            return mappedPosts;
+        }
+
+        // Event walls have no wall page, so posts from them carry the event id to
+        // link to instead.
+        private async Task AssignEventIdsAsync(IList<PostDto> posts)
+        {
+            var eventPosts = posts.Where(post => post.WallType == WallType.Events).ToList();
+
+            if (!eventPosts.Any())
+            {
+                return;
+            }
+
+            var eventWallIds = eventPosts.Select(post => post.WallId).Distinct().ToList();
+
+            var eventIdsByWallId = await _eventsDbSet
+                .Where(@event => eventWallIds.Contains(@event.WallId))
+                .Select(@event => new { @event.WallId, @event.Id })
+                .ToDictionaryAsync(x => x.WallId, x => x.Id);
+
+            foreach (var post in eventPosts)
+            {
+                if (eventIdsByWallId.TryGetValue(post.WallId, out var eventId))
+                {
+                    post.EventId = eventId;
+                }
+            }
+        }
+
+        // Walls of events the user joined or hosts, dropped from the feed a week
+        // after the event ends. Kept out of GetWallsListAsync on purpose: event
+        // walls must not show up in the wall lists that feed the sidebar.
+        private async Task<List<int>> GetRecentEventWallIdsAsync(UserAndOrganizationDto userOrg)
+        {
+            // Users without event access get no event posts. Note the endpoint
+            // itself is gated on BasicPermissions.Post, so a user who can see
+            // events but cannot post still gets nothing from this feed.
+            if (!await _permissionService.UserHasPermissionAsync(userOrg, BasicPermissions.Event))
+            {
+                return new List<int>();
+            }
+
+            var endedAfter = DateTime.UtcNow.AddDays(-EventWallFeedDaysAfterEnd);
+
+            return await _eventsDbSet
+                .Where(@event => @event.OrganizationId == userOrg.OrganizationId &&
+                                 @event.EndDate >= endedAfter &&
+                                 @event.Wall.Members.Any(member => member.UserId == userOrg.UserId))
+                .Select(@event => @event.WallId)
+                .Distinct()
+                .ToListAsync();
         }
 
         private async Task<List<ApplicationUser>> GetUsersAsync(IReadOnlyCollection<Post> posts)

--- a/src/api/Shrooms.Domain/Services/Wall/WallService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/WallService.cs
@@ -31,11 +31,6 @@ namespace Shrooms.Domain.Services.Wall
     {
         private static readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
 
-        // How long an event's wall keeps feeding the followed-walls post feed,
-        // measured from whichever is later: the event ending, or its last post
-        // activity. Discussion often outlives the event itself.
-        private const int EventWallFeedRecentDays = 30;
-
         private readonly IMapper _mapper;
         private readonly IUnitOfWork2 _uow;
         private readonly IPermissionService _permissionService;
@@ -695,6 +690,7 @@ namespace Shrooms.Domain.Services.Wall
             }
 
             List<int> wallsIds;
+            var includeEventWalls = false;
 
             if (wallId.HasValue && WallIsValid(userOrg, wallId.Value))
             {
@@ -703,11 +699,9 @@ namespace Shrooms.Domain.Services.Wall
             else
             {
                 wallsIds = (await GetWallsListAsync(userOrg, wallsListFilter)).Select(w => w.Id).ToList();
-
-                if (wallsListFilter == WallsListFilter.Followed)
-                {
-                    wallsIds.AddRange(await GetRecentEventWallIdsAsync(userOrg));
-                }
+                // The endpoint is gated on BasicPermissions.Post, so a user who can see events but cannot post still gets nothing here.
+                includeEventWalls = wallsListFilter == WallsListFilter.Followed &&
+                                    await _permissionService.UserHasPermissionAsync(userOrg, BasicPermissions.Event);
             }
 
             var entriesCountToSkip = (pageNumber - 1) * pageSize;
@@ -715,14 +709,15 @@ namespace Shrooms.Domain.Services.Wall
             var posts = await _postsDbSet
                 .Include(post => post.Wall)
                 .Include(post => post.Comments)
-                .Where(post => wallsIds.Contains(post.WallId))
+                .Where(BuildWallScope(userOrg, wallsIds, includeEventWalls))
                 .Where(filter)
                 .OrderByDescending(x => x.LastActivity)
                 .Skip(entriesCountToSkip)
                 .Take(pageSize)
                 .ToListAsync();
 
-            var moderators = await _moderatorsDbSet.Where(x => wallsIds.Contains(x.WallId)).ToListAsync();
+            var postWallIds = posts.Select(post => post.WallId).Distinct().ToList();
+            var moderators = await _moderatorsDbSet.Where(x => postWallIds.Contains(x.WallId)).ToListAsync();
             var watchedPosts = await RetrieveWatchedPostsAsync(userOrg.UserId, posts);
             var users = await GetUsersAsync(posts);
 
@@ -765,33 +760,18 @@ namespace Shrooms.Domain.Services.Wall
             }
         }
 
-        // Walls of events the user joined or hosts, dropped from the feed once
-        // both the event and its conversation have gone quiet. Kept out of
-        // GetWallsListAsync on purpose: event walls must not show up in the wall
-        // lists that feed the sidebar.
-        private async Task<List<int>> GetRecentEventWallIdsAsync(UserAndOrganizationDto userOrg)
+        // Event walls are matched by predicate, not id: they must stay out of GetWallsListAsync, which feeds the sidebar.
+        private static Expression<Func<Post, bool>> BuildWallScope(UserAndOrganizationDto userOrg, List<int> wallsIds, bool includeEventWalls)
         {
-            // Users without event access get no event posts. Note the endpoint
-            // itself is gated on BasicPermissions.Post, so a user who can see
-            // events but cannot post still gets nothing from this feed.
-            if (!await _permissionService.UserHasPermissionAsync(userOrg, BasicPermissions.Event))
+            if (!includeEventWalls)
             {
-                return new List<int>();
+                return post => wallsIds.Contains(post.WallId);
             }
 
-            var recentSince = DateTime.UtcNow.AddDays(-EventWallFeedRecentDays);
-
-            // Matching on activity as well as the end date keeps a live thread —
-            // the photos and thanks that land after an event — in the feed, and
-            // stops a long-finished event resurfacing on one stray comment.
-            return await _eventsDbSet
-                .Where(@event => @event.OrganizationId == userOrg.OrganizationId &&
-                                 (@event.EndDate >= recentSince ||
-                                  @event.Wall.Posts.Any(post => post.LastActivity >= recentSince)) &&
-                                 @event.Wall.Members.Any(member => member.UserId == userOrg.UserId))
-                .Select(@event => @event.WallId)
-                .Distinct()
-                .ToListAsync();
+            return post => wallsIds.Contains(post.WallId) ||
+                           (post.Wall.Type == WallType.Events &&
+                            post.Wall.OrganizationId == userOrg.OrganizationId &&
+                            post.Wall.Members.Any(member => member.UserId == userOrg.UserId));
         }
 
         private async Task<List<ApplicationUser>> GetUsersAsync(IReadOnlyCollection<Post> posts)

--- a/src/api/Shrooms.Domain/Services/Wall/WallService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/WallService.cs
@@ -741,15 +741,17 @@ namespace Shrooms.Domain.Services.Wall
 
             var eventWallIds = eventPosts.Select(post => post.WallId).Distinct().ToList();
 
-            // Grouped rather than keyed directly: nothing enforces one event per
-            // wall, and a duplicate must not take down the whole feed.
+            // Nothing enforces one event per wall, so group and pick the latest
+            // rather than letting a duplicate throw or vary between requests.
             var eventIdsByWallId = (await _eventsDbSet
                     .Where(@event => @event.OrganizationId == userOrg.OrganizationId &&
                                      eventWallIds.Contains(@event.WallId))
-                    .Select(@event => new { @event.WallId, @event.Id })
+                    .Select(@event => new { @event.WallId, @event.Id, @event.EndDate })
                     .ToListAsync())
                 .GroupBy(x => x.WallId)
-                .ToDictionary(group => group.Key, group => group.First().Id);
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.OrderByDescending(x => x.EndDate).ThenBy(x => x.Id).First().Id);
 
             foreach (var post in eventPosts)
             {

--- a/src/api/Shrooms.Domain/Services/Wall/WallService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/WallService.cs
@@ -31,9 +31,10 @@ namespace Shrooms.Domain.Services.Wall
     {
         private static readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
 
-        // How long an event's wall keeps feeding the followed-walls post feed
-        // after the event has ended.
-        private const int EventWallFeedDaysAfterEnd = 7;
+        // How long an event's wall keeps feeding the followed-walls post feed,
+        // measured from whichever is later: the event ending, or its last post
+        // activity. Discussion often outlives the event itself.
+        private const int EventWallFeedRecentDays = 30;
 
         private readonly IMapper _mapper;
         private readonly IUnitOfWork2 _uow;
@@ -257,7 +258,7 @@ namespace Shrooms.Domain.Services.Wall
             var users = await GetUsersAsync(postInList);
             var posts = MapPostsWithChildEntitiesToDto(userOrg.UserId, postInList, users, moderators, watchedPosts).ToList();
 
-            await AssignEventIdsAsync(posts);
+            await AssignEventIdsAsync(posts, userOrg);
 
             return posts.FirstOrDefault();
         }
@@ -727,14 +728,14 @@ namespace Shrooms.Domain.Services.Wall
 
             var mappedPosts = MapPostsWithChildEntitiesToDto(userOrg.UserId, posts, users, moderators, watchedPosts).ToList();
 
-            await AssignEventIdsAsync(mappedPosts);
+            await AssignEventIdsAsync(mappedPosts, userOrg);
 
             return mappedPosts;
         }
 
         // Event walls have no wall page, so posts from them carry the event id to
         // link to instead.
-        private async Task AssignEventIdsAsync(IList<PostDto> posts)
+        private async Task AssignEventIdsAsync(IList<PostDto> posts, UserAndOrganizationDto userOrg)
         {
             var eventPosts = posts.Where(post => post.WallType == WallType.Events).ToList();
 
@@ -745,10 +746,15 @@ namespace Shrooms.Domain.Services.Wall
 
             var eventWallIds = eventPosts.Select(post => post.WallId).Distinct().ToList();
 
-            var eventIdsByWallId = await _eventsDbSet
-                .Where(@event => eventWallIds.Contains(@event.WallId))
-                .Select(@event => new { @event.WallId, @event.Id })
-                .ToDictionaryAsync(x => x.WallId, x => x.Id);
+            // Grouped rather than keyed directly: nothing enforces one event per
+            // wall, and a duplicate must not take down the whole feed.
+            var eventIdsByWallId = (await _eventsDbSet
+                    .Where(@event => @event.OrganizationId == userOrg.OrganizationId &&
+                                     eventWallIds.Contains(@event.WallId))
+                    .Select(@event => new { @event.WallId, @event.Id })
+                    .ToListAsync())
+                .GroupBy(x => x.WallId)
+                .ToDictionary(group => group.Key, group => group.First().Id);
 
             foreach (var post in eventPosts)
             {
@@ -759,9 +765,10 @@ namespace Shrooms.Domain.Services.Wall
             }
         }
 
-        // Walls of events the user joined or hosts, dropped from the feed a week
-        // after the event ends. Kept out of GetWallsListAsync on purpose: event
-        // walls must not show up in the wall lists that feed the sidebar.
+        // Walls of events the user joined or hosts, dropped from the feed once
+        // both the event and its conversation have gone quiet. Kept out of
+        // GetWallsListAsync on purpose: event walls must not show up in the wall
+        // lists that feed the sidebar.
         private async Task<List<int>> GetRecentEventWallIdsAsync(UserAndOrganizationDto userOrg)
         {
             // Users without event access get no event posts. Note the endpoint
@@ -772,11 +779,15 @@ namespace Shrooms.Domain.Services.Wall
                 return new List<int>();
             }
 
-            var endedAfter = DateTime.UtcNow.AddDays(-EventWallFeedDaysAfterEnd);
+            var recentSince = DateTime.UtcNow.AddDays(-EventWallFeedRecentDays);
 
+            // Matching on activity as well as the end date keeps a live thread —
+            // the photos and thanks that land after an event — in the feed, and
+            // stops a long-finished event resurfacing on one stray comment.
             return await _eventsDbSet
                 .Where(@event => @event.OrganizationId == userOrg.OrganizationId &&
-                                 @event.EndDate >= endedAfter &&
+                                 (@event.EndDate >= recentSince ||
+                                  @event.Wall.Posts.Any(post => post.LastActivity >= recentSince)) &&
                                  @event.Wall.Members.Any(member => member.UserId == userOrg.UserId))
                 .Select(@event => @event.WallId)
                 .Distinct()

--- a/src/api/Shrooms.Domain/Services/Wall/WallService.cs
+++ b/src/api/Shrooms.Domain/Services/Wall/WallService.cs
@@ -255,7 +255,9 @@ namespace Shrooms.Domain.Services.Wall
             var postInList = new List<Post> { post };
             var watchedPosts = await RetrieveWatchedPostsAsync(userOrg.UserId, postInList);
             var users = await GetUsersAsync(postInList);
-            var posts = MapPostsWithChildEntitiesToDto(userOrg.UserId, postInList, users, moderators, watchedPosts);
+            var posts = MapPostsWithChildEntitiesToDto(userOrg.UserId, postInList, users, moderators, watchedPosts).ToList();
+
+            await AssignEventIdsAsync(posts);
 
             return posts.FirstOrDefault();
         }

--- a/src/api/Shrooms.Tests/DomainService/WallServiceTests.cs
+++ b/src/api/Shrooms.Tests/DomainService/WallServiceTests.cs
@@ -13,6 +13,7 @@ using Shrooms.Contracts.DataTransferObjects.Wall;
 using Shrooms.Contracts.Enums;
 using Shrooms.Contracts.Exceptions;
 using Shrooms.DataLayer.EntityModels.Models;
+using Shrooms.DataLayer.EntityModels.Models.Events;
 using Shrooms.DataLayer.EntityModels.Models.Multiwall;
 using Shrooms.Domain.Exceptions.Exceptions;
 using Shrooms.Domain.Services.Permissions;
@@ -26,10 +27,17 @@ namespace Shrooms.Tests.DomainService
     [TestFixture]
     public class WallServiceTests
     {
+        private const string FeedUserId = "feedUser";
+        private const int FollowedWallId = 1;
+        private const int EventWallId = 2;
+
         private DbSet<Wall> _wallsDbSet;
         private DbSet<WallModerator> _wallModeratorDbSet;
         private DbSet<WallMember> _wallUsersDbSet;
         private DbSet<ApplicationUser> _usersDbSet;
+        private DbSet<Post> _postsDbSet;
+        private DbSet<PostWatcher> _postWatchersDbSet;
+        private DbSet<Event> _eventsDbSet;
         private WallService _wallService;
         private IPermissionService _permissionService;
         private IUnitOfWork2 _uow;
@@ -43,6 +51,9 @@ namespace Shrooms.Tests.DomainService
             _wallModeratorDbSet = _uow.MockDbSetForAsync<WallModerator>();
             _wallUsersDbSet = _uow.MockDbSetForAsync<WallMember>();
             _usersDbSet = _uow.MockDbSetForAsync<ApplicationUser>();
+            _postsDbSet = _uow.MockDbSetForAsync<Post>();
+            _postWatchersDbSet = _uow.MockDbSetForAsync<PostWatcher>();
+            _eventsDbSet = _uow.MockDbSetForAsync<Event>();
 
             _permissionService = Substitute.For<IPermissionService>();
             var roleService = Substitute.For<IRoleService>();
@@ -964,6 +975,227 @@ namespace Shrooms.Tests.DomainService
                     permission,
                     userOrg,
                     checkForAdministrationEventPermission));
+        }
+
+        [Test]
+        public async Task Should_Return_Event_Wall_Posts_With_Event_Id_In_Followed_Feed()
+        {
+            // Arrange
+            var eventId = MockPostsForFollowedFeed(DateTime.UtcNow.AddDays(-1));
+            MockEventPermission(true);
+
+            // Act
+            var posts = (await _wallService.GetAllPostsAsync(1, 10, FeedUser(), WallsListFilter.Followed)).ToList();
+
+            // Assert
+            Assert.That(posts.Select(p => p.WallId), Is.EquivalentTo(new[] { FollowedWallId, EventWallId }));
+            Assert.That(posts.First(p => p.WallId == EventWallId).EventId, Is.EqualTo(eventId));
+            Assert.That(posts.First(p => p.WallId == FollowedWallId).EventId, Is.Null);
+        }
+
+        [TestCase(WallsListFilter.All)]
+        [TestCase(WallsListFilter.NotHiddenFromAllWalls)]
+        [TestCase(WallsListFilter.NotFollowed)]
+        public async Task Should_Not_Return_Event_Wall_Posts_For_Filters_Other_Than_Followed(WallsListFilter filter)
+        {
+            // Arrange
+            MockPostsForFollowedFeed(DateTime.UtcNow.AddDays(-1));
+            MockEventPermission(true);
+
+            // Act
+            var posts = (await _wallService.GetAllPostsAsync(1, 10, FeedUser(), filter)).ToList();
+
+            // Assert
+            Assert.That(posts.Any(p => p.WallId == EventWallId), Is.False);
+        }
+
+        [Test]
+        public async Task Should_Not_Return_Event_Wall_Posts_When_User_Has_No_Event_Permission()
+        {
+            // Arrange
+            MockPostsForFollowedFeed(DateTime.UtcNow.AddDays(-1));
+            MockEventPermission(false);
+
+            // Act
+            var posts = (await _wallService.GetAllPostsAsync(1, 10, FeedUser(), WallsListFilter.Followed)).ToList();
+
+            // Assert
+            Assert.That(posts.Any(p => p.WallId == EventWallId), Is.False);
+        }
+
+        [TestCase(1, true)]
+        [TestCase(-29, true)]
+        [TestCase(-31, false)]
+        public async Task Should_Return_Event_Wall_Posts_Only_Until_A_Month_After_The_Event_Ended(int endDateOffsetInDays, bool shouldBeReturned)
+        {
+            // Arrange. The conversation is as stale as the event, so the end date
+            // alone decides.
+            MockPostsForFollowedFeed(
+                DateTime.UtcNow.AddDays(endDateOffsetInDays),
+                eventPostLastActivity: DateTime.UtcNow.AddDays(endDateOffsetInDays));
+            MockEventPermission(true);
+
+            // Act
+            var posts = (await _wallService.GetAllPostsAsync(1, 10, FeedUser(), WallsListFilter.Followed)).ToList();
+
+            // Assert
+            Assert.That(posts.Any(p => p.WallId == EventWallId), Is.EqualTo(shouldBeReturned));
+        }
+
+        [Test]
+        public async Task Should_Return_Event_Wall_Posts_While_The_Conversation_Is_Still_Active()
+        {
+            // Arrange
+            MockPostsForFollowedFeed(
+                DateTime.UtcNow.AddDays(-90),
+                eventPostLastActivity: DateTime.UtcNow.AddDays(-1));
+            MockEventPermission(true);
+
+            // Act
+            var posts = (await _wallService.GetAllPostsAsync(1, 10, FeedUser(), WallsListFilter.Followed)).ToList();
+
+            // Assert
+            Assert.That(posts.Any(p => p.WallId == EventWallId), Is.True);
+        }
+
+        [Test]
+        public async Task Should_Not_Return_Event_Wall_Posts_When_User_Did_Not_Join_The_Event()
+        {
+            // Arrange
+            MockPostsForFollowedFeed(DateTime.UtcNow.AddDays(-1), isEventWallMember: false);
+            MockEventPermission(true);
+
+            // Act
+            var posts = (await _wallService.GetAllPostsAsync(1, 10, FeedUser(), WallsListFilter.Followed)).ToList();
+
+            // Assert
+            Assert.That(posts.Any(p => p.WallId == EventWallId), Is.False);
+        }
+
+        [Test]
+        public async Task Should_Not_Return_Event_Wall_Posts_From_Another_Organization()
+        {
+            // Arrange
+            MockPostsForFollowedFeed(DateTime.UtcNow.AddDays(-1), eventOrganizationId: 3);
+            MockEventPermission(true);
+
+            // Act
+            var posts = (await _wallService.GetAllPostsAsync(1, 10, FeedUser(), WallsListFilter.Followed)).ToList();
+
+            // Assert
+            Assert.That(posts.Any(p => p.WallId == EventWallId), Is.False);
+        }
+
+        [Test]
+        public async Task Should_Return_Event_Id_For_A_Single_Event_Wall_Post()
+        {
+            // Arrange
+            var eventId = MockPostsForFollowedFeed(DateTime.UtcNow.AddDays(-1));
+
+            // Act
+            var eventPost = await _wallService.GetWallPostAsync(FeedUser(), EventWallId);
+            var followedWallPost = await _wallService.GetWallPostAsync(FeedUser(), FollowedWallId);
+
+            // Assert
+            Assert.That(eventPost.EventId, Is.EqualTo(eventId));
+            Assert.That(followedWallPost.EventId, Is.Null);
+        }
+
+        private static UserAndOrganizationDto FeedUser()
+        {
+            return new UserAndOrganizationDto { UserId = FeedUserId, OrganizationId = 2 };
+        }
+
+        private void MockEventPermission(bool hasPermission)
+        {
+            _permissionService.UserHasPermissionAsync(Arg.Any<UserAndOrganizationDto>(), BasicPermissions.Event).Returns(hasPermission);
+        }
+
+        // Wall 1 is a user created wall the user follows, wall 2 is the wall of an event the user joined; each holds one post with the same id as its wall.
+        private Guid MockPostsForFollowedFeed(
+            DateTime eventEndDate,
+            bool isEventWallMember = true,
+            int eventOrganizationId = 2,
+            DateTime? eventPostLastActivity = null)
+        {
+            var followedWallMember = new WallMember { Id = 1, UserId = FeedUserId, WallId = FollowedWallId };
+            var eventWallMembers = isEventWallMember
+                ? new List<WallMember> { new() { Id = 2, UserId = FeedUserId, WallId = EventWallId } }
+                : new List<WallMember>();
+
+            var followedWall = new Wall
+            {
+                Id = FollowedWallId,
+                Name = "Followed wall",
+                Type = WallType.UserCreated,
+                OrganizationId = 2,
+                Members = new List<WallMember> { followedWallMember },
+                Moderators = new List<WallModerator>(),
+                Posts = new List<Post>()
+            };
+
+            var eventWall = new Wall
+            {
+                Id = EventWallId,
+                Name = "Event wall",
+                Type = WallType.Events,
+                OrganizationId = 2,
+                Members = eventWallMembers,
+                Moderators = new List<WallModerator>(),
+                Posts = new List<Post>()
+            };
+
+            var followedWallPost = new Post
+            {
+                Id = FollowedWallId,
+                WallId = FollowedWallId,
+                Wall = followedWall,
+                AuthorId = FeedUserId,
+                LastActivity = DateTime.UtcNow,
+                Comments = new List<Comment>(),
+                Likes = new LikesCollection()
+            };
+
+            var eventWallPost = new Post
+            {
+                Id = EventWallId,
+                WallId = EventWallId,
+                Wall = eventWall,
+                AuthorId = FeedUserId,
+                LastActivity = eventPostLastActivity ?? DateTime.UtcNow.AddMinutes(-1),
+                Comments = new List<Comment>(),
+                Likes = new LikesCollection()
+            };
+
+            var posts = new List<Post> { followedWallPost, eventWallPost };
+
+            // The feed matches event walls on post activity, so the navigation
+            // collections have to mirror the posts set, not stay empty.
+            followedWall.Posts = new List<Post> { followedWallPost };
+            eventWall.Posts = new List<Post> { eventWallPost };
+
+            var eventId = Guid.NewGuid();
+            var events = new List<Event>
+            {
+                new()
+                {
+                    Id = eventId,
+                    Name = "Event",
+                    OrganizationId = eventOrganizationId,
+                    WallId = EventWallId,
+                    Wall = eventWall,
+                    EndDate = eventEndDate
+                }
+            };
+
+            _wallsDbSet.SetDbSetDataForAsync(new List<Wall> { followedWall, eventWall });
+            _wallUsersDbSet.SetDbSetDataForAsync(new List<WallMember> { followedWallMember }.Concat(eventWallMembers).ToList());
+            _wallModeratorDbSet.SetDbSetDataForAsync(new List<WallModerator>());
+            _postsDbSet.SetDbSetDataForAsync(posts);
+            _postWatchersDbSet.SetDbSetDataForAsync(new List<PostWatcher>());
+            _eventsDbSet.SetDbSetDataForAsync(events);
+
+            return eventId;
         }
 
         private static void MockRoleService(IRoleService roleService)

--- a/src/api/Shrooms.Tests/DomainService/WallServiceTests.cs
+++ b/src/api/Shrooms.Tests/DomainService/WallServiceTests.cs
@@ -981,7 +981,7 @@ namespace Shrooms.Tests.DomainService
         public async Task Should_Return_Event_Wall_Posts_With_Event_Id_In_Followed_Feed()
         {
             // Arrange
-            var eventId = MockPostsForFollowedFeed(DateTime.UtcNow.AddDays(-1));
+            var eventId = MockPostsForFollowedFeed();
             MockEventPermission(true);
 
             // Act
@@ -999,7 +999,7 @@ namespace Shrooms.Tests.DomainService
         public async Task Should_Not_Return_Event_Wall_Posts_For_Filters_Other_Than_Followed(WallsListFilter filter)
         {
             // Arrange
-            MockPostsForFollowedFeed(DateTime.UtcNow.AddDays(-1));
+            MockPostsForFollowedFeed();
             MockEventPermission(true);
 
             // Act
@@ -1013,7 +1013,7 @@ namespace Shrooms.Tests.DomainService
         public async Task Should_Not_Return_Event_Wall_Posts_When_User_Has_No_Event_Permission()
         {
             // Arrange
-            MockPostsForFollowedFeed(DateTime.UtcNow.AddDays(-1));
+            MockPostsForFollowedFeed();
             MockEventPermission(false);
 
             // Act
@@ -1023,32 +1023,11 @@ namespace Shrooms.Tests.DomainService
             Assert.That(posts.Any(p => p.WallId == EventWallId), Is.False);
         }
 
-        [TestCase(1, true)]
-        [TestCase(-29, true)]
-        [TestCase(-31, false)]
-        public async Task Should_Return_Event_Wall_Posts_Only_Until_A_Month_After_The_Event_Ended(int endDateOffsetInDays, bool shouldBeReturned)
-        {
-            // Arrange. The conversation is as stale as the event, so the end date
-            // alone decides.
-            MockPostsForFollowedFeed(
-                DateTime.UtcNow.AddDays(endDateOffsetInDays),
-                eventPostLastActivity: DateTime.UtcNow.AddDays(endDateOffsetInDays));
-            MockEventPermission(true);
-
-            // Act
-            var posts = (await _wallService.GetAllPostsAsync(1, 10, FeedUser(), WallsListFilter.Followed)).ToList();
-
-            // Assert
-            Assert.That(posts.Any(p => p.WallId == EventWallId), Is.EqualTo(shouldBeReturned));
-        }
-
         [Test]
-        public async Task Should_Return_Event_Wall_Posts_While_The_Conversation_Is_Still_Active()
+        public async Task Should_Return_Event_Wall_Posts_Long_After_The_Event_Ended()
         {
             // Arrange
-            MockPostsForFollowedFeed(
-                DateTime.UtcNow.AddDays(-90),
-                eventPostLastActivity: DateTime.UtcNow.AddDays(-1));
+            MockPostsForFollowedFeed(eventEndDate: DateTime.UtcNow.AddYears(-2), eventPostLastActivity: DateTime.UtcNow.AddYears(-2));
             MockEventPermission(true);
 
             // Act
@@ -1062,7 +1041,7 @@ namespace Shrooms.Tests.DomainService
         public async Task Should_Not_Return_Event_Wall_Posts_When_User_Did_Not_Join_The_Event()
         {
             // Arrange
-            MockPostsForFollowedFeed(DateTime.UtcNow.AddDays(-1), isEventWallMember: false);
+            MockPostsForFollowedFeed(isEventWallMember: false);
             MockEventPermission(true);
 
             // Act
@@ -1076,7 +1055,7 @@ namespace Shrooms.Tests.DomainService
         public async Task Should_Not_Return_Event_Wall_Posts_From_Another_Organization()
         {
             // Arrange
-            MockPostsForFollowedFeed(DateTime.UtcNow.AddDays(-1), eventOrganizationId: 3);
+            MockPostsForFollowedFeed(eventOrganizationId: 3);
             MockEventPermission(true);
 
             // Act
@@ -1090,7 +1069,7 @@ namespace Shrooms.Tests.DomainService
         public async Task Should_Return_Event_Id_For_A_Single_Event_Wall_Post()
         {
             // Arrange
-            var eventId = MockPostsForFollowedFeed(DateTime.UtcNow.AddDays(-1));
+            var eventId = MockPostsForFollowedFeed();
 
             // Act
             var eventPost = await _wallService.GetWallPostAsync(FeedUser(), EventWallId);
@@ -1113,10 +1092,10 @@ namespace Shrooms.Tests.DomainService
 
         // Wall 1 is a user created wall the user follows, wall 2 is the wall of an event the user joined; each holds one post with the same id as its wall.
         private Guid MockPostsForFollowedFeed(
-            DateTime eventEndDate,
             bool isEventWallMember = true,
             int eventOrganizationId = 2,
-            DateTime? eventPostLastActivity = null)
+            DateTime? eventPostLastActivity = null,
+            DateTime? eventEndDate = null)
         {
             var followedWallMember = new WallMember { Id = 1, UserId = FeedUserId, WallId = FollowedWallId };
             var eventWallMembers = isEventWallMember
@@ -1139,7 +1118,7 @@ namespace Shrooms.Tests.DomainService
                 Id = EventWallId,
                 Name = "Event wall",
                 Type = WallType.Events,
-                OrganizationId = 2,
+                OrganizationId = eventOrganizationId,
                 Members = eventWallMembers,
                 Moderators = new List<WallModerator>(),
                 Posts = new List<Post>()
@@ -1169,8 +1148,6 @@ namespace Shrooms.Tests.DomainService
 
             var posts = new List<Post> { followedWallPost, eventWallPost };
 
-            // The feed matches event walls on post activity, so the navigation
-            // collections have to mirror the posts set, not stay empty.
             followedWall.Posts = new List<Post> { followedWallPost };
             eventWall.Posts = new List<Post> { eventWallPost };
 
@@ -1184,7 +1161,7 @@ namespace Shrooms.Tests.DomainService
                     OrganizationId = eventOrganizationId,
                     WallId = EventWallId,
                     Wall = eventWall,
-                    EndDate = eventEndDate
+                    EndDate = eventEndDate ?? DateTime.UtcNow.AddDays(-1)
                 }
             };
 


### PR DESCRIPTION
Event walls were excluded from the followed-walls post query, so posts and comments from events a user joined never reached My walls. The followed feed now also pulls the walls of events the user joined or hosts, until a week after the event ends.

The extra wall ids are added in the post query rather than in GetWallsListAsync, so event walls stay out of the wall lists the sidebar renders. Users without event permission get none of these posts.

Posts carry the event id when they come from an event wall, since event walls have no wall page for a client to link to.