### PR TITLE
feat(events): add MyFoodTeam endpoint for the food team widget

### DIFF
--- a/src/api/Shrooms.Premium.Tests/DomainService/EventListingServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventListingServiceTests.cs
@@ -693,7 +693,7 @@ namespace Shrooms.Premium.Tests.DomainService
         }
 
         [Test]
-        public async Task Should_Return_Joined_Food_Team_Within_The_Next_Seven_Days()
+        public async Task Should_Return_Joined_Food_Team_Within_The_Eight_Day_Horizon()
         {
             // Arrange
             var guids = MockFoodTeamEvents();
@@ -801,11 +801,29 @@ namespace Shrooms.Premium.Tests.DomainService
             ClassicAssert.IsNull(result.JoinedEvent);
         }
 
+        [Test]
+        public async Task Should_Return_The_Type_Of_The_Joined_Food_Team_When_Organization_Has_Several()
+        {
+            // Arrange
+            var guids = MockFoodTeamEvents();
+
+            // Act
+            var result = await _eventListingService.GetMyFoodTeamAsync(new UserAndOrganizationDto
+            {
+                OrganizationId = 2,
+                UserId = "testUserJoinedSecondFoodType"
+            });
+
+            // Assert
+            ClassicAssert.AreEqual(13, result.EventTypeId);
+            ClassicAssert.AreEqual(guids[6], result.JoinedEvent.Id);
+        }
+
         #region Mocks
 
         private Guid[] MockFoodTeamEvents()
         {
-            var guids = Enumerable.Repeat(0, 6).Select(_ => Guid.NewGuid()).ToArray();
+            var guids = Enumerable.Repeat(0, 7).Select(_ => Guid.NewGuid()).ToArray();
             var now = DateTime.UtcNow;
 
             var eventTypes = new List<EventType>
@@ -832,6 +850,16 @@ namespace Shrooms.Premium.Tests.DomainService
                     Name = "Food",
                     OrganizationId = 3,
                     IsSingleJoin = false,
+                    SendWeeklyReminders = true
+                },
+
+                // A second food type in the same organization, so the widget has to pick one.
+                new EventType
+                {
+                    Id = 13,
+                    Name = "Breakfast",
+                    OrganizationId = 2,
+                    IsSingleJoin = true,
                     SendWeeklyReminders = true
                 }
             };
@@ -927,6 +955,20 @@ namespace Shrooms.Premium.Tests.DomainService
                     EventParticipants = new List<EventParticipant>
                     {
                         new EventParticipant { Id = 6, ApplicationUserId = "testUserTwoTeamsSameDay", AttendStatus = (int)AttendingStatus.Attending }
+                    }
+                },
+                new Event
+                {
+                    Id = guids[6],
+                    Name = "Breakfast club",
+                    Place = "Kitchen",
+                    StartDate = now.AddHours(-1),
+                    EndDate = now.AddHours(1),
+                    OrganizationId = 2,
+                    EventTypeId = 13,
+                    EventParticipants = new List<EventParticipant>
+                    {
+                        new EventParticipant { Id = 8, ApplicationUserId = "testUserJoinedSecondFoodType", AttendStatus = (int)AttendingStatus.Attending }
                     }
                 }
             };

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventListingServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventListingServiceTests.cs
@@ -25,6 +25,7 @@ namespace Shrooms.Premium.Tests.DomainService
     public class EventListingServiceTests
     {
         private DbSet<Event> _eventsDbSet;
+        private DbSet<EventType> _eventTypesDbSet;
         private DbSet<Office> _officeDbSet;
         private DbSet<EventParticipant> _eventParticipantsDbSet;
         private DbSet<KudosType> _kudosTypesDbSet;
@@ -40,6 +41,7 @@ namespace Shrooms.Premium.Tests.DomainService
             var uow = Substitute.For<IUnitOfWork2>();
 
             _eventsDbSet = uow.MockDbSetForAsync<Event>();
+            _eventTypesDbSet = uow.MockDbSetForAsync<EventType>();
             _officeDbSet = uow.MockDbSetForAsync<Office>();
             _eventParticipantsDbSet = uow.MockDbSetForAsync<EventParticipant>();
             _kudosLogDbSet = uow.MockDbSetForAsync<KudosLog>();
@@ -654,7 +656,286 @@ namespace Shrooms.Premium.Tests.DomainService
             CollectionAssert.AreEqual(expectedEventIdsByNameOrder, result.Select(item => item.Id));
         }
 
+        [Test]
+        public async Task Should_Return_No_Food_Team_When_Organization_Has_No_Food_Event_Type()
+        {
+            // Arrange
+            MockFoodTeamEvents();
+
+            // Act
+            var result = await _eventListingService.GetMyFoodTeamAsync(new UserAndOrganizationDto
+            {
+                OrganizationId = 3,
+                UserId = "testUser1"
+            });
+
+            // Assert
+            ClassicAssert.IsNull(result.EventTypeId);
+            ClassicAssert.IsNull(result.JoinedEvent);
+        }
+
+        [Test]
+        public async Task Should_Return_Food_Event_Type_Without_Joined_Event_When_User_Has_Not_Joined()
+        {
+            // Arrange
+            MockFoodTeamEvents();
+
+            // Act
+            var result = await _eventListingService.GetMyFoodTeamAsync(new UserAndOrganizationDto
+            {
+                OrganizationId = 2,
+                UserId = "userWithoutFoodTeam"
+            });
+
+            // Assert
+            ClassicAssert.AreEqual(10, result.EventTypeId);
+            ClassicAssert.IsNull(result.JoinedEvent);
+        }
+
+        [Test]
+        public async Task Should_Return_Joined_Food_Team_Within_The_Next_Seven_Days()
+        {
+            // Arrange
+            var guids = MockFoodTeamEvents();
+
+            // Act
+            var result = await _eventListingService.GetMyFoodTeamAsync(new UserAndOrganizationDto
+            {
+                OrganizationId = 2,
+                UserId = "testUser1"
+            });
+
+            // Assert
+            ClassicAssert.AreEqual(10, result.EventTypeId);
+            ClassicAssert.AreEqual(guids[0], result.JoinedEvent.Id);
+            ClassicAssert.AreEqual("Pizza Friday", result.JoinedEvent.Name);
+            ClassicAssert.AreEqual("Kitchen", result.JoinedEvent.Place);
+        }
+
+        // This week's food day is over, so the widget rolls over to next week's team even though
+        // it starts a little more than seven days out.
+        [Test]
+        public async Task Should_Return_Next_Weeks_Food_Team_When_This_Weeks_Is_Over()
+        {
+            // Arrange
+            var guids = MockFoodTeamEvents();
+
+            // Act
+            var result = await _eventListingService.GetMyFoodTeamAsync(new UserAndOrganizationDto
+            {
+                OrganizationId = 2,
+                UserId = "testUserJoinedNextWeek"
+            });
+
+            // Assert
+            ClassicAssert.AreEqual(guids[5], result.JoinedEvent.Id);
+            ClassicAssert.AreEqual("Next week pizza", result.JoinedEvent.Name);
+        }
+
+        [Test]
+        public async Task Should_Not_Return_Food_Team_Joined_Beyond_The_Coming_Food_Day()
+        {
+            // Arrange
+            MockFoodTeamEvents();
+
+            // Act
+            var result = await _eventListingService.GetMyFoodTeamAsync(new UserAndOrganizationDto
+            {
+                OrganizationId = 2,
+                UserId = "testUserJoinedFarFuture"
+            });
+
+            // Assert
+            ClassicAssert.IsNull(result.JoinedEvent);
+        }
+
+        [Test]
+        public async Task Should_Return_The_Later_Food_Team_When_An_Earlier_One_Already_Finished_Today()
+        {
+            // Arrange
+            var guids = MockFoodTeamEvents();
+
+            // Act
+            var result = await _eventListingService.GetMyFoodTeamAsync(new UserAndOrganizationDto
+            {
+                OrganizationId = 2,
+                UserId = "testUserTwoTeamsSameDay"
+            });
+
+            // Assert
+            ClassicAssert.AreEqual(guids[4], result.JoinedEvent.Id);
+            ClassicAssert.AreEqual("Late lunch pizza", result.JoinedEvent.Name);
+        }
+
+        [Test]
+        public async Task Should_Not_Return_Food_Team_The_User_Declined()
+        {
+            // Arrange
+            MockFoodTeamEvents();
+
+            // Act
+            var result = await _eventListingService.GetMyFoodTeamAsync(new UserAndOrganizationDto
+            {
+                OrganizationId = 2,
+                UserId = "testUserNotAttending"
+            });
+
+            // Assert
+            ClassicAssert.IsNull(result.JoinedEvent);
+        }
+
+        [Test]
+        public async Task Should_Not_Return_Food_Team_Of_A_Non_Food_Event_Type()
+        {
+            // Arrange
+            MockFoodTeamEvents();
+
+            // Act
+            var result = await _eventListingService.GetMyFoodTeamAsync(new UserAndOrganizationDto
+            {
+                OrganizationId = 2,
+                UserId = "testUserJoinedOtherType"
+            });
+
+            // Assert
+            ClassicAssert.IsNull(result.JoinedEvent);
+        }
+
         #region Mocks
+
+        private Guid[] MockFoodTeamEvents()
+        {
+            var guids = Enumerable.Repeat(0, 6).Select(_ => Guid.NewGuid()).ToArray();
+            var now = DateTime.UtcNow;
+
+            var eventTypes = new List<EventType>
+            {
+                new EventType
+                {
+                    Id = 10,
+                    Name = "Food",
+                    OrganizationId = 2,
+                    IsSingleJoin = true,
+                    SendWeeklyReminders = true
+                },
+                new EventType
+                {
+                    Id = 11,
+                    Name = "Sports",
+                    OrganizationId = 2,
+                    IsSingleJoin = true,
+                    SendWeeklyReminders = false
+                },
+                new EventType
+                {
+                    Id = 12,
+                    Name = "Food",
+                    OrganizationId = 3,
+                    IsSingleJoin = false,
+                    SendWeeklyReminders = true
+                }
+            };
+
+            var events = new List<Event>
+            {
+                // Ongoing, so it always falls inside the current week regardless of when the test runs.
+                new Event
+                {
+                    Id = guids[0],
+                    Name = "Pizza Friday",
+                    Place = "Kitchen",
+                    ImageName = "pizza.png",
+                    StartDate = now.AddHours(-1),
+                    EndDate = now.AddHours(1),
+                    OrganizationId = 2,
+                    EventTypeId = 10,
+                    EventParticipants = new List<EventParticipant>
+                    {
+                        new EventParticipant { Id = 1, ApplicationUserId = "testUser1", AttendStatus = (int)AttendingStatus.Attending },
+                        new EventParticipant { Id = 2, ApplicationUserId = "testUserNotAttending", AttendStatus = (int)AttendingStatus.NotAttending }
+                    }
+                },
+                new Event
+                {
+                    Id = guids[1],
+                    Name = "Far future pizza",
+                    Place = "Kitchen",
+                    StartDate = now.AddDays(10),
+                    EndDate = now.AddDays(10).AddHours(2),
+                    OrganizationId = 2,
+                    EventTypeId = 10,
+                    EventParticipants = new List<EventParticipant>
+                    {
+                        new EventParticipant { Id = 3, ApplicationUserId = "testUserJoinedFarFuture", AttendStatus = (int)AttendingStatus.Attending }
+                    }
+                },
+
+                // Next week's team, scheduled slightly later in the day than this week's.
+                new Event
+                {
+                    Id = guids[5],
+                    Name = "Next week pizza",
+                    Place = "Kitchen",
+                    StartDate = now.AddDays(7).AddHours(2),
+                    EndDate = now.AddDays(7).AddHours(3),
+                    OrganizationId = 2,
+                    EventTypeId = 10,
+                    EventParticipants = new List<EventParticipant>
+                    {
+                        new EventParticipant { Id = 7, ApplicationUserId = "testUserJoinedNextWeek", AttendStatus = (int)AttendingStatus.Attending }
+                    }
+                },
+                new Event
+                {
+                    Id = guids[2],
+                    Name = "Basketball",
+                    Place = "Court",
+                    StartDate = now.AddHours(-1),
+                    EndDate = now.AddHours(1),
+                    OrganizationId = 2,
+                    EventTypeId = 11,
+                    EventParticipants = new List<EventParticipant>
+                    {
+                        new EventParticipant { Id = 4, ApplicationUserId = "testUserJoinedOtherType", AttendStatus = (int)AttendingStatus.Attending }
+                    }
+                },
+
+                // Two food teams the same day for one user: the first has already finished.
+                new Event
+                {
+                    Id = guids[3],
+                    Name = "Early lunch pizza",
+                    Place = "Kitchen",
+                    StartDate = now.AddHours(-2),
+                    EndDate = now.AddMinutes(-30),
+                    OrganizationId = 2,
+                    EventTypeId = 10,
+                    EventParticipants = new List<EventParticipant>
+                    {
+                        new EventParticipant { Id = 5, ApplicationUserId = "testUserTwoTeamsSameDay", AttendStatus = (int)AttendingStatus.Attending }
+                    }
+                },
+                new Event
+                {
+                    Id = guids[4],
+                    Name = "Late lunch pizza",
+                    Place = "Kitchen",
+                    StartDate = now.AddMinutes(30),
+                    EndDate = now.AddHours(2),
+                    OrganizationId = 2,
+                    EventTypeId = 10,
+                    EventParticipants = new List<EventParticipant>
+                    {
+                        new EventParticipant { Id = 6, ApplicationUserId = "testUserTwoTeamsSameDay", AttendStatus = (int)AttendingStatus.Attending }
+                    }
+                }
+            };
+
+            _eventTypesDbSet.SetDbSetDataForAsync(eventTypes);
+            _eventsDbSet.SetDbSetDataForAsync(events);
+
+            return guids;
+        }
 
         private Guid[] MockVisitedReportEvents()
         {

--- a/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/FoodTeamEventDto.cs
+++ b/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/FoodTeamEventDto.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Shrooms.Premium.DataTransferObjects.Models.Events
+{
+    public class FoodTeamEventDto
+    {
+        public Guid Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Place { get; set; }
+
+        public string ImageName { get; set; }
+
+        public DateTime StartDate { get; set; }
+
+        public DateTime EndDate { get; set; }
+    }
+}

--- a/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/FoodTeamWidgetDto.cs
+++ b/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/FoodTeamWidgetDto.cs
@@ -2,10 +2,11 @@ namespace Shrooms.Premium.DataTransferObjects.Models.Events
 {
     public class FoodTeamWidgetDto
     {
-        // Null when the organization has no food event type configured.
+        // The joined event's type, or the organization's first food event type when there is no
+        // joined event. Null when the organization has no food event type configured.
         public int? EventTypeId { get; set; }
 
-        // Null when the user has not joined a food team in the next 7 days.
+        // Null when the user has not joined a food team within the coming 8 days.
         public FoodTeamEventDto JoinedEvent { get; set; }
     }
 }

--- a/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/FoodTeamWidgetDto.cs
+++ b/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/FoodTeamWidgetDto.cs
@@ -1,0 +1,11 @@
+namespace Shrooms.Premium.DataTransferObjects.Models.Events
+{
+    public class FoodTeamWidgetDto
+    {
+        // Null when the organization has no food event type configured.
+        public int? EventTypeId { get; set; }
+
+        // Null when the user has not joined a food team in the next 7 days.
+        public FoodTeamEventDto JoinedEvent { get; set; }
+    }
+}

--- a/src/api/Shrooms.Premium/Domain/Services/Events/List/EventListingService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/List/EventListingService.cs
@@ -24,6 +24,11 @@ namespace Shrooms.Premium.Domain.Services.Events.List
     {
         private const string OutsideOffice = "[]";
 
+        // The food team widget is about the coming food day, so a team joined further out is skipped.
+        // Eight rather than seven days so next week's team is reachable the moment this week's ends,
+        // even when it is scheduled later in the day.
+        private const int FoodTeamHorizonInDays = 8;
+
         private static readonly Dictionary<MyEventsOptions, Func<string, Expression<Func<Event, bool>>>>
             _eventFilters = new ()
             {
@@ -34,6 +39,7 @@ namespace Shrooms.Premium.Domain.Services.Events.List
         private readonly IEventValidationService _eventValidationService;
 
         private readonly DbSet<Event> _eventsDbSet;
+        private readonly DbSet<EventType> _eventTypesDbSet;
         private readonly DbSet<KudosLog> _kudosLogDbSet;
         private readonly DbSet<KudosType> _kudosTypesDbSet;
         private readonly DbSet<EventParticipant> _eventParticipantsDbSet;
@@ -43,6 +49,7 @@ namespace Shrooms.Premium.Domain.Services.Events.List
         {
             _eventValidationService = eventValidationService;
             _eventsDbSet = uow.GetDbSet<Event>();
+            _eventTypesDbSet = uow.GetDbSet<EventType>();
             _kudosLogDbSet = uow.GetDbSet<KudosLog>();
             _kudosTypesDbSet = uow.GetDbSet<KudosType>();
             _eventParticipantsDbSet = uow.GetDbSet<EventParticipant>();
@@ -90,6 +97,57 @@ namespace Shrooms.Premium.Domain.Services.Events.List
                 .Select(MapEventToListItemDto(userOrganization.UserId));
 
             return await events.ToListAsync();
+        }
+
+        // Feeds the wall's food team ("Pizza Friday") widget: the single-join weekly-reminder
+        // event type for the organization, plus the joined event of that type coming up next.
+        public async Task<FoodTeamWidgetDto> GetMyFoodTeamAsync(UserAndOrganizationDto userOrg)
+        {
+            var foodTypeIds = await _eventTypesDbSet
+                .Where(type => type.OrganizationId == userOrg.OrganizationId && type.IsSingleJoin && type.SendWeeklyReminders)
+                .OrderBy(type => type.Id)
+                .Select(type => type.Id)
+                .ToListAsync();
+
+            if (foodTypeIds.Count == 0)
+            {
+                return new FoodTeamWidgetDto();
+            }
+
+            return new FoodTeamWidgetDto
+            {
+                EventTypeId = foodTypeIds[0],
+                JoinedEvent = await GetJoinedFoodTeamEventAsync(foodTypeIds, userOrg)
+            };
+        }
+
+        private async Task<FoodTeamEventDto> GetJoinedFoodTeamEventAsync(List<int> foodTypeIds, UserAndOrganizationDto userOrg)
+        {
+            var now = DateTime.UtcNow;
+            var horizon = now.AddDays(FoodTeamHorizonInDays);
+
+            // EndDate > now keeps an ongoing team and skips one that already finished today,
+            // so a second team starting later the same day is the one that surfaces.
+            return await _eventsDbSet
+                .Where(e => e.OrganizationId == userOrg.OrganizationId &&
+                            foodTypeIds.Contains(e.EventTypeId) &&
+                            e.EndDate > now &&
+                            e.StartDate < horizon &&
+                            e.EventParticipants.Any(p => p.ApplicationUserId == userOrg.UserId &&
+                                                         (p.AttendStatus == (int)AttendingStatus.Attending ||
+                                                          p.AttendStatus == (int)AttendingStatus.MaybeAttending ||
+                                                          p.AttendStatus == (int)AttendingStatus.AttendingVirtually)))
+                .OrderBy(e => e.StartDate)
+                .Select(e => new FoodTeamEventDto
+                {
+                    Id = e.Id,
+                    Name = e.Name,
+                    Place = e.Place,
+                    ImageName = e.ImageName,
+                    StartDate = e.StartDate,
+                    EndDate = e.EndDate
+                })
+                .FirstOrDefaultAsync();
         }
 
         public async Task<IPagedList<EventDetailsListItemDto>> GetNotStartedEventsFilteredByTitleAsync(EventReportListingArgsDto reportArgsDto, UserAndOrganizationDto userAndOrganization)

--- a/src/api/Shrooms.Premium/Domain/Services/Events/List/EventListingService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/List/EventListingService.cs
@@ -114,21 +114,25 @@ namespace Shrooms.Premium.Domain.Services.Events.List
                 return new FoodTeamWidgetDto();
             }
 
+            var joined = await GetJoinedFoodTeamEventAsync(foodTypeIds, userOrg);
+
             return new FoodTeamWidgetDto
             {
-                EventTypeId = foodTypeIds[0],
-                JoinedEvent = await GetJoinedFoodTeamEventAsync(foodTypeIds, userOrg)
+                // The joined team's own type wins, so the two fields never point at different
+                // types when an organization has more than one food event type configured.
+                EventTypeId = joined?.EventTypeId ?? foodTypeIds[0],
+                JoinedEvent = joined?.Event
             };
         }
 
-        private async Task<FoodTeamEventDto> GetJoinedFoodTeamEventAsync(List<int> foodTypeIds, UserAndOrganizationDto userOrg)
+        private async Task<(int EventTypeId, FoodTeamEventDto Event)?> GetJoinedFoodTeamEventAsync(List<int> foodTypeIds, UserAndOrganizationDto userOrg)
         {
             var now = DateTime.UtcNow;
             var horizon = now.AddDays(FoodTeamHorizonInDays);
 
             // EndDate > now keeps an ongoing team and skips one that already finished today,
             // so a second team starting later the same day is the one that surfaces.
-            return await _eventsDbSet
+            var joined = await _eventsDbSet
                 .Where(e => e.OrganizationId == userOrg.OrganizationId &&
                             foodTypeIds.Contains(e.EventTypeId) &&
                             e.EndDate > now &&
@@ -138,16 +142,27 @@ namespace Shrooms.Premium.Domain.Services.Events.List
                                                           p.AttendStatus == (int)AttendingStatus.MaybeAttending ||
                                                           p.AttendStatus == (int)AttendingStatus.AttendingVirtually)))
                 .OrderBy(e => e.StartDate)
-                .Select(e => new FoodTeamEventDto
+                .Select(e => new
                 {
-                    Id = e.Id,
-                    Name = e.Name,
-                    Place = e.Place,
-                    ImageName = e.ImageName,
-                    StartDate = e.StartDate,
-                    EndDate = e.EndDate
+                    e.EventTypeId,
+                    Event = new FoodTeamEventDto
+                    {
+                        Id = e.Id,
+                        Name = e.Name,
+                        Place = e.Place,
+                        ImageName = e.ImageName,
+                        StartDate = e.StartDate,
+                        EndDate = e.EndDate
+                    }
                 })
                 .FirstOrDefaultAsync();
+
+            if (joined is null)
+            {
+                return null;
+            }
+
+            return (joined.EventTypeId, joined.Event);
         }
 
         public async Task<IPagedList<EventDetailsListItemDto>> GetNotStartedEventsFilteredByTitleAsync(EventReportListingArgsDto reportArgsDto, UserAndOrganizationDto userAndOrganization)

--- a/src/api/Shrooms.Premium/Domain/Services/Events/List/IEventListingService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/List/IEventListingService.cs
@@ -17,6 +17,8 @@ namespace Shrooms.Premium.Domain.Services.Events.List
 
         Task<IEnumerable<EventListItemDto>> GetEventsFilteredAsync(EventFilteredArgsDto filteredArgsDto, UserAndOrganizationDto userOrganization);
 
+        Task<FoodTeamWidgetDto> GetMyFoodTeamAsync(UserAndOrganizationDto userOrg);
+
         Task<IPagedList<EventDetailsListItemDto>> GetNotStartedEventsFilteredByTitleAsync(EventReportListingArgsDto reportArgsDto, UserAndOrganizationDto userAndOrganization);
 
         Task<IPagedList<EventParticipantReportDto>> GetReportParticipantsAsync(EventParticipantsReportListingArgsDto reportArgsDto, UserAndOrganizationDto userOrg);

--- a/src/api/Shrooms.Premium/Presentation/Api/Controllers/EventController.cs
+++ b/src/api/Shrooms.Premium/Presentation/Api/Controllers/EventController.cs
@@ -258,6 +258,18 @@ namespace Shrooms.Premium.Presentation.Api.Controllers
         }
 
         [HttpGet]
+        [Route("MyFoodTeam")]
+        [PermissionAuthorize(Permission = BasicPermissions.Event)]
+        [ProducesResponseType(typeof(FoodTeamWidgetViewModel), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetMyFoodTeam()
+        {
+            var foodTeamDto = await _eventListingService.GetMyFoodTeamAsync(GetUserAndOrganization());
+            var result = _mapper.Map<FoodTeamWidgetDto, FoodTeamWidgetViewModel>(foodTeamDto);
+
+            return Ok(result);
+        }
+
+        [HttpGet]
         [Route("Options")]
         [PermissionAuthorize(Permission = BasicPermissions.Event)]
         [ProducesResponseType(typeof(EventOptionsViewModel), StatusCodes.Status200OK)]

--- a/src/api/Shrooms.Premium/Presentation/ModelMappings/Profiles/EventsProfile.cs
+++ b/src/api/Shrooms.Premium/Presentation/ModelMappings/Profiles/EventsProfile.cs
@@ -24,6 +24,8 @@ namespace Shrooms.Premium.Presentation.ModelMappings.Profiles
             CreateMap<EventListItemDto, EventListItemViewModel>(MemberList.None)
                 .ForMember(dest => dest.OfficeIds, opt => opt.MapFrom(u => JsonConvert.DeserializeObject<string[]>(u.Offices.Value)));
             CreateMap<EventDetailsListItemDto, EventDetailsListItemViewModel>(MemberList.None);
+            CreateMap<FoodTeamEventDto, FoodTeamEventViewModel>(MemberList.None);
+            CreateMap<FoodTeamWidgetDto, FoodTeamWidgetViewModel>(MemberList.None);
             CreateMap<EventOptionDto, EventOptionViewModel>(MemberList.None);
             CreateMap<EventDetailsDto, EventDetailsViewModel>(MemberList.None)
                 .Ignore(x => x.Comments)

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/FoodTeamEventViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/FoodTeamEventViewModel.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Shrooms.Premium.Presentation.WebViewModels.Events
+{
+    public class FoodTeamEventViewModel
+    {
+        public Guid Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Place { get; set; }
+
+        public string ImageName { get; set; }
+
+        public DateTime StartDate { get; set; }
+
+        public DateTime EndDate { get; set; }
+    }
+}

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/FoodTeamWidgetViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/FoodTeamWidgetViewModel.cs
@@ -1,0 +1,11 @@
+namespace Shrooms.Premium.Presentation.WebViewModels.Events
+{
+    public class FoodTeamWidgetViewModel
+    {
+        // Null when the organization has no food event type configured.
+        public int? EventTypeId { get; set; }
+
+        // Null when the user has not joined a food team in the next 7 days.
+        public FoodTeamEventViewModel JoinedEvent { get; set; }
+    }
+}

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/FoodTeamWidgetViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/FoodTeamWidgetViewModel.cs
@@ -2,10 +2,11 @@ namespace Shrooms.Premium.Presentation.WebViewModels.Events
 {
     public class FoodTeamWidgetViewModel
     {
-        // Null when the organization has no food event type configured.
+        // The joined event's type, or the organization's first food event type when there is no
+        // joined event. Null when the organization has no food event type configured.
         public int? EventTypeId { get; set; }
 
-        // Null when the user has not joined a food team in the next 7 days.
+        // Null when the user has not joined a food team within the coming 8 days.
         public FoodTeamEventViewModel JoinedEvent { get; set; }
     }
 }


### PR DESCRIPTION
Resolves the organization's food event type (single-join with weekly reminders) and the joined event of that type for the coming food day. The wall widget previously paged through /Events with a hardcoded event type id and filtered RSVP status and the date window client-side.

An event drops out once its own EndDate passes, so a second team later the same day surfaces as soon as the earlier one finishes, and the widget rolls over to next week's team without a fixed clock time.