### PR TITLE
feat(kudos): filter the user kudos log by type server-side

### DIFF
--- a/src/api/Shrooms.Contracts.DataTransferObjects/Models/Kudos/KudosPieChartSliceDto.cs
+++ b/src/api/Shrooms.Contracts.DataTransferObjects/Models/Kudos/KudosPieChartSliceDto.cs
@@ -2,7 +2,18 @@
 {
     public class KudosPieChartSliceDto
     {
+        /// <summary>
+        /// Display name. Translated to the user's culture for the built-in
+        /// types, so it must never be used to match against stored data.
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// The stored, untranslated kudos type name. Culture-independent, so
+        /// this is the value to send back when filtering the kudos log.
+        /// </summary>
+        public string TypeName { get; set; }
+
         public decimal Value { get; set; }
     }
 }

--- a/src/api/Shrooms.Domain/Services/Kudos/IKudosService.cs
+++ b/src/api/Shrooms.Domain/Services/Kudos/IKudosService.cs
@@ -55,8 +55,7 @@ namespace Shrooms.Domain.Services.Kudos
         Task UpdateProfilesFromUserIdsAsync(IEnumerable<string> usersId, UserAndOrganizationDto userOrg);
 
         Task<KudosLogsEntriesDto<MainKudosLogDto>> GetKudosLogsAsync(KudosLogsFilterDto options);
-
-        Task<KudosLogsEntriesDto<KudosUserLogDto>> GetUserKudosLogsAsync(string userId, int page, int organizationId);
+        Task<KudosLogsEntriesDto<KudosUserLogDto>> GetUserKudosLogsAsync(string userId, int page, int organizationId, IReadOnlyCollection<string> filteringTypes = null);
 
         Task<int> GetKudosTypeIdAsync(string kudosTypeName);
 

--- a/src/api/Shrooms.Domain/Services/Kudos/KudosService.cs
+++ b/src/api/Shrooms.Domain/Services/Kudos/KudosService.cs
@@ -226,11 +226,19 @@ namespace Shrooms.Domain.Services.Kudos
             };
         }
 
-        public async Task<KudosLogsEntriesDto<KudosUserLogDto>> GetUserKudosLogsAsync(string userId, int page, int organizationId)
+        public async Task<KudosLogsEntriesDto<KudosUserLogDto>> GetUserKudosLogsAsync(string userId, int page, int organizationId, IReadOnlyCollection<string> filteringTypes = null)
         {
             await ValidateUserAsync(organizationId, userId);
 
-            var userLogsQuery = (from kudLog in _kudosLogsDbSet
+            var typeNames = filteringTypes?
+                .Where(type => !string.IsNullOrWhiteSpace(type))
+                .ToArray();
+
+            var filteredLogs = typeNames == null || typeNames.Length == 0
+                ? _kudosLogsDbSet
+                : _kudosLogsDbSet.Where(log => typeNames.Contains(log.KudosTypeName));
+
+            var userLogsQuery = (from kudLog in filteredLogs
                                  where kudLog.EmployeeId == userId && kudLog.OrganizationId == organizationId
                                  from usr in _usersDbSet.Where(u => u.Id == kudLog.CreatedBy).DefaultIfEmpty()
                                  select new KudosUserLogDto
@@ -253,7 +261,7 @@ namespace Shrooms.Domain.Services.Kudos
                                          Id = usr == null ? string.Empty : kudLog.CreatedBy
                                      },
                                      PictureId = kudLog.PictureId
-                                 }).OrderByDescending(o => o.Created);
+                                 }).OrderByDescending(o => o.Created).ThenByDescending(o => o.Id);
 
             var logCount = await userLogsQuery.CountAsync();
 
@@ -401,27 +409,20 @@ namespace Shrooms.Domain.Services.Kudos
                 .ToListAsync();
 
             var user = await _usersDbSet.FindAsync(userId);
-
-            if (user != null)
-            {
-                var culture = CultureInfo.GetCultureInfo(user.CultureCode ?? "en-US");
-
-                foreach (var kudosLog in kudosLogs)
-                {
-                    if (IsTranslatableKudosType(kudosLog.KudosSystemType))
-                    {
-                        kudosLog.KudosTypeName = TranslateKudos($"KudosType{kudosLog.KudosTypeName}", culture);
-                    }
-                }
-            }
+            var culture = user == null ? null : CultureInfo.GetCultureInfo(user.CultureCode ?? "en-US");
 
             var pieChart = kudosLogs
                 .GroupBy(log => log.KudosTypeName)
+                .OrderBy(group => group.Key, StringComparer.Ordinal)
                 .Select(group => new KudosPieChartSliceDto
                 {
-                    Name = group.Key,
+                    TypeName = group.Key,
+                    Name = culture != null && group.Any(log => IsTranslatableKudosType(log.KudosSystemType))
+                        ? TranslateKudos($"KudosType{group.Key}", culture)
+                        : group.Key,
                     Value = group.Sum(log => log.Points)
-                });
+                })
+                .ToList();
 
             return pieChart;
         }

--- a/src/api/Shrooms.Presentation.Common/Controllers/Kudos/KudosController.cs
+++ b/src/api/Shrooms.Presentation.Common/Controllers/Kudos/KudosController.cs
@@ -72,14 +72,14 @@ namespace Shrooms.Presentation.Common.Controllers.Kudos
         [HttpGet]
         [PermissionAuthorize(Permission = BasicPermissions.Kudos)]
         [ProducesResponseType(typeof(PagedViewModel<KudosUserLogViewModel>), StatusCodes.Status200OK)]
-        public async Task<IActionResult> GetUserKudosLogs(string userId, int page = 1)
+        public async Task<IActionResult> GetUserKudosLogs(string userId, int page = 1, [FromQuery] string[] filteringType = null)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
             }
 
-            var kudosLogsEntriesDto = await _kudosService.GetUserKudosLogsAsync(userId, page, GetUserAndOrganization().OrganizationId);
+            var kudosLogsEntriesDto = await _kudosService.GetUserKudosLogsAsync(userId, page, GetUserAndOrganization().OrganizationId, filteringType);
             var userKudosLogsViewModel = _mapper.Map<IEnumerable<KudosUserLogDto>, IEnumerable<KudosUserLogViewModel>>(kudosLogsEntriesDto.KudosLogs).ToList();
             var pagedKudosLogs = new PagedViewModel<KudosUserLogViewModel>
             {

--- a/src/api/Shrooms.Presentation.WebViewModels/Models/Users/Kudos/KudosPieChartSliceViewModel.cs
+++ b/src/api/Shrooms.Presentation.WebViewModels/Models/Users/Kudos/KudosPieChartSliceViewModel.cs
@@ -2,7 +2,16 @@
 {
     public class KudosPieChartSliceViewModel
     {
+        /// <summary>
+        /// Display name, translated to the user's culture for built-in types.
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Stored, untranslated type name — the value to pass back as the
+        /// kudos log's filteringType.
+        /// </summary>
+        public string TypeName { get; set; }
 
         public decimal Value { get; set; }
     }

--- a/src/api/Shrooms.Tests/DomainService/KudosServiceTests.cs
+++ b/src/api/Shrooms.Tests/DomainService/KudosServiceTests.cs
@@ -157,6 +157,50 @@ namespace Shrooms.Tests.DomainService
         }
 
         [Test]
+        public async Task Should_Return_Only_Matching_Type_When_User_Kudos_Logs_Are_Filtered()
+        {
+            var result = await _kudosService.GetUserKudosLogsAsync("testUserId", 1, 2, new[] { "Type1" });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.TotalKudosCount, Is.EqualTo(2));
+                Assert.That(result.KudosLogs.Count(), Is.EqualTo(2));
+                Assert.That(result.KudosLogs.All(log => log.Type.Name == "Type1"), Is.True);
+            });
+        }
+
+        [Test]
+        public async Task Should_Return_Every_Selected_Type_When_User_Kudos_Logs_Are_Filtered_By_Several()
+        {
+            var result = await _kudosService.GetUserKudosLogsAsync("testUserId", 1, 2, new[] { "Type1", "Type2" });
+
+            Assert.That(result.TotalKudosCount, Is.EqualTo(3));
+        }
+
+        [Test]
+        public async Task Should_Return_All_Types_When_User_Kudos_Logs_Filter_Is_Not_Set()
+        {
+            var unfiltered = await _kudosService.GetUserKudosLogsAsync("testUserId", 1, 2);
+            var empty = await _kudosService.GetUserKudosLogsAsync("testUserId", 1, 2, new string[0]);
+            var blank = await _kudosService.GetUserKudosLogsAsync("testUserId", 1, 2, new[] { "  " });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(unfiltered.TotalKudosCount, Is.EqualTo(3));
+                Assert.That(empty.TotalKudosCount, Is.EqualTo(3));
+                Assert.That(blank.TotalKudosCount, Is.EqualTo(3));
+            });
+        }
+
+        [Test]
+        public async Task Should_Treat_All_As_An_Ordinary_Type_Name_When_Filtering_User_Kudos_Logs()
+        {
+            var result = await _kudosService.GetUserKudosLogsAsync("testUserId", 1, 2, new[] { BusinessLayerConstants.KudosFilteringTypeAllFilter });
+
+            Assert.That(result.TotalKudosCount, Is.EqualTo(0));
+        }
+
+        [Test]
         public async Task Should_Return_Specific_User_Kudos_Logs_With_Organization_Filter()
         {
             MockKudosLogsForOrganizationTest();
@@ -347,6 +391,65 @@ namespace Shrooms.Tests.DomainService
             Assert.That(result.First().Value, Is.EqualTo(2));
             Assert.That(result.ToArray()[1].Value, Is.EqualTo(10));
             Assert.That(result.ToArray()[1].Name, Is.EqualTo("Type2"));
+        }
+
+        [Test]
+        public async Task Should_Group_Pie_Chart_Slices_By_Stored_Name_Regardless_Of_System_Type()
+        {
+            var logs = new List<KudosLog>
+            {
+                PieChartLog(1, "Other", KudosTypeEnum.Ordinary, 2),
+                PieChartLog(2, "Other", KudosTypeEnum.Other, 3)
+            };
+            _kudosLogsDbSet.SetDbSetDataForAsync(logs.AsQueryable());
+
+            var forward = (await _kudosService.GetKudosPieChartDataAsync(2, "UserId")).ToList();
+
+            logs.Reverse();
+            _kudosLogsDbSet.SetDbSetDataForAsync(logs.AsQueryable());
+            var reversed = (await _kudosService.GetKudosPieChartDataAsync(2, "UserId")).ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(forward.Count, Is.EqualTo(1));
+                Assert.That(forward.Single().TypeName, Is.EqualTo("Other"));
+                Assert.That(forward.Single().Value, Is.EqualTo(5));
+                Assert.That(reversed.Single().Name, Is.EqualTo(forward.Single().Name));
+            });
+        }
+
+        private static KudosLog PieChartLog(int id, string typeName, KudosTypeEnum systemType, decimal points)
+        {
+            return new KudosLog
+            {
+                Id = id,
+                EmployeeId = "UserId",
+                OrganizationId = 2,
+                Status = KudosStatus.Approved,
+                KudosTypeName = typeName,
+                KudosSystemType = systemType,
+                Points = points,
+                Comments = string.Empty
+            };
+        }
+
+        [Test]
+        public async Task Should_Return_Pie_Chart_Slices_In_A_Deterministic_Order()
+        {
+            MockKudosLogsForPieChart();
+            var result = (await _kudosService.GetKudosPieChartDataAsync(2, "UserId")).ToList();
+            var names = result.Select(slice => slice.TypeName).ToList();
+            Assert.That(names, Is.EqualTo(names.OrderBy(name => name, StringComparer.Ordinal).ToList()));
+        }
+
+        [Test]
+        public async Task Should_Expose_Untranslated_Type_Name_On_Pie_Chart_Slices()
+        {
+            MockKudosLogsForPieChart();
+            var result = (await _kudosService.GetKudosPieChartDataAsync(2, "UserId")).ToList();
+
+            Assert.That(result.All(slice => !string.IsNullOrEmpty(slice.TypeName)), Is.True);
+            Assert.That(result.ToArray()[1].TypeName, Is.EqualTo("Type2"));
         }
 
         [Test]


### PR DESCRIPTION
Lets `GetUserKudosLogs` filter by kudos type, so the count it returns
describes the filtered set. Needed by the new frontend, where the kudos
log's pager currently offers pages that are empty once a filter is on

**Notes**
- Backwards compatible with the AngularJS frontend: it sends only
  `userId` + `page`, so the filter defaults to off, and it reads only
  `name`/`value` from the pie, so `TypeName` is ignored.
- One visible change in the old app: **pie slice order**, and therefore
  its by-index colours — they shift once, then stay stable.
- The grouping change could have merged slices where one stored name
  spans two `KudosSystemType`s. Checked against PROD: no such rows, so
  grouping is identical there.