### PR TITLE
fix(rooms): guard null applicationUsers in Room/Put

### DIFF
--- a/src/api/Shrooms.Presentation.Api/Controllers/RoomController.cs
+++ b/src/api/Shrooms.Presentation.Api/Controllers/RoomController.cs
@@ -77,8 +77,11 @@ namespace Shrooms.Presentation.Api.Controllers
                 _repository.Update(model);
                 await _unitOfWork.SaveAsync();
 
-                await RemoveRoomForUsersAsync(roomViewModel);
-                await AddRoomsForUsersAsync(roomViewModel);
+                if (roomViewModel.ApplicationUsers != null)
+                {
+                    await RemoveRoomForUsersAsync(roomViewModel);
+                    await AddRoomsForUsersAsync(roomViewModel);
+                }
             }
             catch (Exception)
             {


### PR DESCRIPTION
Put dereferenced roomViewModel.ApplicationUsers unconditionally, so any update omitting the field threw a NullReferenceException that the blanket catch turned into a bodyless 400. Guard it the way Post already does, so omitting applicationUsers leaves room membership untouched.