### PR TITLE
Kudos - match the pie chart total to the profile kudos total

### DIFF
--- a/src/api/Shrooms.Domain/Services/Kudos/KudosService.cs
+++ b/src/api/Shrooms.Domain/Services/Kudos/KudosService.cs
@@ -411,15 +411,20 @@ namespace Shrooms.Domain.Services.Kudos
         {
             await ValidateUserAsync(organizationId, userId);
 
+            var user = await _usersDbSet.FindAsync(userId);
+            var employmentDate = user?.EmploymentDate;
+
             var kudosLogs = await _kudosLogsDbSet
                 .Where(kudos =>
                     kudos.EmployeeId == userId &&
                     kudos.Status == KudosStatus.Approved &&
+                    (employmentDate == null || kudos.Created >= employmentDate) &&
                     kudos.KudosSystemType != KudosTypeEnum.Minus &&
+                    kudos.KudosSystemType != KudosTypeEnum.Refund &&
+                    kudos.KudosBasketId == null &&
                     kudos.OrganizationId == organizationId)
                 .ToListAsync();
 
-            var user = await _usersDbSet.FindAsync(userId);
             var culture = user == null ? null : CultureInfo.GetCultureInfo(user.CultureCode ?? "en-US");
 
             var pieChart = kudosLogs

--- a/src/api/Shrooms.Tests/DomainService/KudosServiceTests.cs
+++ b/src/api/Shrooms.Tests/DomainService/KudosServiceTests.cs
@@ -452,6 +452,96 @@ namespace Shrooms.Tests.DomainService
         }
 
         [Test]
+        public async Task Should_Exclude_Refund_Logs_From_Pie_Chart()
+        {
+            _kudosLogsDbSet.SetDbSetDataForAsync(new List<KudosLog>
+            {
+                PieChartLog(1, "Other", KudosTypeEnum.Ordinary, 10),
+                PieChartLog(2, "Refund", KudosTypeEnum.Refund, 9)
+            }.AsQueryable());
+
+            var result = (await _kudosService.GetKudosPieChartDataAsync(2, "UserId")).ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Count, Is.EqualTo(1));
+                Assert.That(result.Single().TypeName, Is.EqualTo("Other"));
+                Assert.That(result.Sum(slice => slice.Value), Is.EqualTo(10));
+            });
+        }
+
+        [Test]
+        public async Task Should_Exclude_Basket_Donation_Logs_From_Pie_Chart()
+        {
+            var donation = PieChartLog(2, "Other", KudosTypeEnum.Ordinary, 5);
+            donation.KudosBasketId = 1;
+
+            _kudosLogsDbSet.SetDbSetDataForAsync(new List<KudosLog>
+            {
+                PieChartLog(1, "Other", KudosTypeEnum.Ordinary, 10),
+                donation
+            }.AsQueryable());
+
+            var result = (await _kudosService.GetKudosPieChartDataAsync(2, "UserId")).ToList();
+
+            Assert.That(result.Single().Value, Is.EqualTo(10));
+        }
+
+        [Test]
+        public async Task Should_Exclude_Pie_Chart_Logs_Created_Before_The_Employment_Date()
+        {
+            var employmentDate = DateTime.UtcNow.AddMonths(-1);
+            _usersDbSet.FindAsync("PieUserId").Returns(new ApplicationUser
+            {
+                Id = "PieUserId",
+                OrganizationId = 2,
+                CultureCode = "en-US",
+                EmploymentDate = employmentDate
+            });
+
+            var before = PieChartLog(1, "Before", KudosTypeEnum.Ordinary, 7);
+            before.EmployeeId = "PieUserId";
+            before.Created = employmentDate.AddDays(-1);
+
+            var after = PieChartLog(2, "After", KudosTypeEnum.Ordinary, 3);
+            after.EmployeeId = "PieUserId";
+            after.Created = employmentDate.AddDays(1);
+
+            _kudosLogsDbSet.SetDbSetDataForAsync(new List<KudosLog> { before, after }.AsQueryable());
+
+            var result = (await _kudosService.GetKudosPieChartDataAsync(2, "PieUserId")).ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Count, Is.EqualTo(1));
+                Assert.That(result.Single().TypeName, Is.EqualTo("After"));
+                Assert.That(result.Single().Value, Is.EqualTo(3));
+            });
+        }
+
+        [Test]
+        public async Task Should_Not_Blank_The_Pie_Chart_When_The_Employment_Date_Is_Missing()
+        {
+            _usersDbSet.FindAsync("NoDateUserId").Returns(new ApplicationUser
+            {
+                Id = "NoDateUserId",
+                OrganizationId = 2,
+                CultureCode = "en-US",
+                EmploymentDate = null
+            });
+
+            var log = PieChartLog(1, "Other", KudosTypeEnum.Ordinary, 4);
+            log.EmployeeId = "NoDateUserId";
+            log.Created = DateTime.UtcNow.AddYears(-5);
+
+            _kudosLogsDbSet.SetDbSetDataForAsync(new List<KudosLog> { log }.AsQueryable());
+
+            var result = (await _kudosService.GetKudosPieChartDataAsync(2, "NoDateUserId")).ToList();
+
+            Assert.That(result.Single().Value, Is.EqualTo(4));
+        }
+
+        [Test]
         public async Task Should_Return_Pie_Chart_Slices_In_A_Deterministic_Order()
         {
             MockKudosLogsForPieChart();


### PR DESCRIPTION
Problem. The kudos pie chart and the profile "Received" total were computed from different predicates.

Cause. GetKudosPieChartDataAsync excluded only Minus. The profile total (SetKudosToUserProfileAsync) also excludes Refund, basket donations and pre-employment logs. Every other positive-kudos surface — the wall widget, the profile total, the type picker — already excludes Refund; the pie was the only one that missed it.

Fix. Align the pie's predicate with the profile total's. Refund logs come from exactly one place, LotteryAbortJob, so they're aborted-lottery ticket refunds — your own kudos returned, not recognition received.

Note on EmploymentDate: guarded with employmentDate == null || rather than copied verbatim, so a missing date means "no cutoff" instead of blanking the chart entirely.