### PR TITLE
Event sign-up steps 2/3: read and write paths

### DIFF
--- a/src/api/Shrooms.Premium.Tests/Controllers/ViewModels/EventQuestionMappingTests.cs
+++ b/src/api/Shrooms.Premium.Tests/Controllers/ViewModels/EventQuestionMappingTests.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using AutoMapper;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using NUnit.Framework;
 using Shrooms.Contracts.Enums;
 using Shrooms.DataLayer.EntityModels.Models.Events;
@@ -207,6 +209,59 @@ namespace Shrooms.Premium.Tests.Controllers.ViewModels
             var viewModel = _mapper.Map<EventQuestionStructureDto, EventQuestionViewModel>(dto);
 
             Assert.That(viewModel.ShowIf, Is.Null);
+        }
+
+        [Test]
+        public void Should_Map_Question_Structure_To_The_SignUp_Read_Model()
+        {
+            var dto = new EventQuestionStructureDto
+            {
+                Id = 7,
+                ClientId = "ignored",
+                Title = "Pick your dish",
+                Order = 2,
+                SelectType = EventQuestionSelectType.Multi,
+                IsRequired = true,
+                ShowIfOptionId = 101,
+                ShowIfOptionClientId = "ignored",
+                Options = new List<EventQuestionOptionStructureDto>
+                {
+                    new EventQuestionOptionStructureDto { Id = 11, Name = "Pizza", Order = 0, Rule = OptionRules.Default }
+                }
+            };
+
+            var result = _mapper.Map<EventQuestionStructureDto, EventSignUpQuestionViewModel>(dto);
+
+            Assert.That(result.Id, Is.EqualTo(7));
+            Assert.That(result.Title, Is.EqualTo("Pick your dish"));
+            Assert.That(result.Order, Is.EqualTo(2));
+            Assert.That(result.SelectType, Is.EqualTo(EventQuestionSelectType.Multi));
+            Assert.That(result.IsRequired, Is.True);
+            Assert.That(result.ShowIfOptionId, Is.EqualTo(101));
+            Assert.That(result.Options, Has.Count.EqualTo(1));
+            Assert.That(result.Options[0].Id, Is.EqualTo(11));
+            Assert.That(result.Options[0].Name, Is.EqualTo("Pizza"));
+            Assert.That(result.Options[0].Order, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Should_Serialize_SelectType_As_A_String_For_The_Client()
+        {
+            var viewModel = new EventSignUpQuestionViewModel
+            {
+                Id = 1,
+                Title = "Pick your dish",
+                SelectType = EventQuestionSelectType.Single,
+                ShowIfOptionId = null
+            };
+
+            var json = JsonConvert.SerializeObject(viewModel, new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            });
+
+            Assert.That(json, Does.Contain("\"selectType\":\"Single\""));
+            Assert.That(json, Does.Contain("\"showIfOptionId\":null"));
         }
     }
 }

--- a/src/api/Shrooms.Premium.Tests/Controllers/WebApi/EventControllerTests.cs
+++ b/src/api/Shrooms.Premium.Tests/Controllers/WebApi/EventControllerTests.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
@@ -257,6 +259,31 @@ namespace Shrooms.Premium.Tests.Controllers.WebApi
             Assert.That(body.Errors, Has.Count.EqualTo(1));
             Assert.That(body.Errors[0].QuestionId, Is.EqualTo(12));
             Assert.That(body.Errors[0].Reason, Is.EqualTo(EventAnswerErrorReason.RequiredAnswerMissing));
+        }
+
+        [Test]
+        public void Should_Serialize_Answer_Error_Reason_As_A_String_For_The_Client()
+        {
+            var viewModel = new EventAnswersInvalidViewModel
+            {
+                Code = "EventAnswersInvalid",
+                Errors = new List<EventAnswerErrorViewModel>
+                {
+                    new EventAnswerErrorViewModel
+                    {
+                        QuestionId = 12,
+                        Reason = EventAnswerErrorReason.RequiredAnswerMissing
+                    }
+                }
+            };
+
+            var json = JsonConvert.SerializeObject(viewModel, new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            });
+
+            Assert.That(json, Does.Contain("\"reason\":\"RequiredAnswerMissing\""));
+            Assert.That(json, Does.Contain("\"questionId\":12"));
         }
     }
 }

--- a/src/api/Shrooms.Premium.Tests/Controllers/WebApi/EventControllerTests.cs
+++ b/src/api/Shrooms.Premium.Tests/Controllers/WebApi/EventControllerTests.cs
@@ -4,9 +4,11 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
+using Shrooms.Contracts.Enums;
 using Shrooms.Contracts.DataTransferObjects;
 using Shrooms.Contracts.Infrastructure;
 using Shrooms.Domain.Services.Wall.Posts;
+using Shrooms.Premium.Constants;
 using Shrooms.Premium.DataTransferObjects.Models.Events;
 using Shrooms.Premium.Domain.DomainExceptions.Event;
 using Shrooms.Premium.Domain.Services.Events;
@@ -255,7 +257,7 @@ namespace Shrooms.Premium.Tests.Controllers.WebApi
 
             Assert.That(result.GetStatusCode(), Is.EqualTo(HttpStatusCode.BadRequest));
             var body = result.GetContent<EventAnswersInvalidViewModel>();
-            Assert.That(body.Code, Is.EqualTo("EventAnswersInvalid"));
+            Assert.That(body.Code, Is.EqualTo(PremiumErrorCodes.EventAnswersInvalid));
             Assert.That(body.Errors, Has.Count.EqualTo(1));
             Assert.That(body.Errors[0].QuestionId, Is.EqualTo(12));
             Assert.That(body.Errors[0].Reason, Is.EqualTo(EventAnswerErrorReason.RequiredAnswerMissing));

--- a/src/api/Shrooms.Premium.Tests/Controllers/WebApi/EventControllerTests.cs
+++ b/src/api/Shrooms.Premium.Tests/Controllers/WebApi/EventControllerTests.cs
@@ -19,6 +19,7 @@ using Shrooms.Premium.Presentation.WebViewModels.Events;
 using Shrooms.Premium.Tests.ModelMappings;
 using Shrooms.Tests.Extensions;
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,6 +33,7 @@ namespace Shrooms.Premium.Tests.Controllers.WebApi
 
         private IEventService _eventService;
         private IEventListingService _eventListingService;
+        private IEventParticipationService _eventParticipationService;
 
         [SetUp]
         public void TestInitializer()
@@ -40,9 +42,9 @@ namespace Shrooms.Premium.Tests.Controllers.WebApi
 
             _eventService = Substitute.For<IEventService>();
             _eventListingService = Substitute.For<IEventListingService>();
+            _eventParticipationService = Substitute.For<IEventParticipationService>();
 
             var eventUtilitiesService = Substitute.For<IEventUtilitiesService>();
-            var eventParticipationService = Substitute.For<IEventParticipationService>();
             var eventCalendarService = Substitute.For<IEventCalendarService>();
             var eventExportService = Substitute.For<IEventExportService>();
             var postService = Substitute.For<IPostService>();
@@ -54,7 +56,7 @@ namespace Shrooms.Premium.Tests.Controllers.WebApi
                 _eventService,
                 _eventListingService,
                 eventUtilitiesService,
-                eventParticipationService,
+                _eventParticipationService,
                 eventCalendarService,
                 eventExportService,
                 postService,
@@ -235,6 +237,26 @@ namespace Shrooms.Premium.Tests.Controllers.WebApi
 
             // Assert
             ClassicAssert.AreEqual(HttpStatusCode.OK, httpActionResult.GetStatusCode());
+        }
+
+        [Test]
+        public async Task Join_Should_Return_The_Offending_Questions_When_Answers_Are_Invalid()
+        {
+            _eventParticipationService
+                .JoinAsync(Arg.Any<EventJoinDto>())
+                .Returns(Task.FromException(new EventAnswersInvalidException(new List<EventAnswerErrorDto>
+                {
+                    new EventAnswerErrorDto { QuestionId = 12, Reason = EventAnswerErrorReason.RequiredAnswerMissing }
+                })));
+
+            var result = await _eventController.Join(new EventJoinViewModel { EventId = Guid.NewGuid() });
+
+            Assert.That(result.GetStatusCode(), Is.EqualTo(HttpStatusCode.BadRequest));
+            var body = result.GetContent<EventAnswersInvalidViewModel>();
+            Assert.That(body.Code, Is.EqualTo("EventAnswersInvalid"));
+            Assert.That(body.Errors, Has.Count.EqualTo(1));
+            Assert.That(body.Errors[0].QuestionId, Is.EqualTo(12));
+            Assert.That(body.Errors[0].Reason, Is.EqualTo(EventAnswerErrorReason.RequiredAnswerMissing));
         }
     }
 }

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventCrudServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventCrudServiceTests.cs
@@ -618,6 +618,173 @@ namespace Shrooms.Premium.Tests.DomainService
             await _uow.Received(1).SaveChangesAsync(false);
         }
 
+        // Regression test for the reported bug: MapToEventEditDetailsDto used to leak
+        // question-owned options into the flat Options list, the client echoed them back as
+        // EditedOptions, and UpdateEventAsync's totalOptionsProvided count made
+        // CheckIfCreatingEventHasNoChoices throw even though MaxChoices == 0 is correct for a
+        // question-only event. This chains GetEventForEditingAsync into UpdateEventAsync, the
+        // same way the real host-edit flow does, so it fails before the fix and passes after.
+        [Test]
+        public async Task Should_Not_Throw_MaxChoice_Exception_When_Updating_Question_Only_Event()
+        {
+            var users = MockUsers();
+            var eventTypes = MockEventTypes();
+            var office = MockOffices().First();
+            var eventId = Guid.NewGuid();
+
+            var questionOptions = new List<EventOption>
+            {
+                new EventOption { Id = 101, Option = "Pizza", QuestionId = 5, EventId = eventId },
+                new EventOption { Id = 102, Option = "Pasta", QuestionId = 5, EventId = eventId }
+            };
+
+            var question = new EventQuestion
+            {
+                Id = 5,
+                EventId = eventId,
+                Title = "Pick your dish",
+                Order = 0,
+                SelectType = EventQuestionSelectType.Single,
+                IsRequired = true,
+                Options = questionOptions
+            };
+
+            var @event = new Event
+            {
+                Id = eventId,
+                StartDate = DateTime.UtcNow.AddDays(4),
+                EndDate = DateTime.UtcNow.AddDays(4),
+                Created = DateTime.UtcNow,
+                ResponsibleUserId = users.First().Id,
+                ResponsibleUser = users.First(),
+                EventRecurring = EventRecurrenceOptions.None,
+                ImageName = "imageUrl",
+                Name = "Question-only event",
+                Place = "City",
+                MaxParticipants = 15,
+                OrganizationId = 1,
+                Description = "desc",
+                EventOptions = questionOptions,
+                EventQuestions = new List<EventQuestion> { question },
+                EventParticipants = new List<EventParticipant>(),
+                Offices = $"[\"{office.Id}\"]",
+                RegistrationDeadline = DateTime.UtcNow,
+                MaxChoices = 0,
+                EventType = eventTypes.Last(),
+                EventTypeId = eventTypes.Last().Id,
+                Reminders = new List<EventReminder>()
+            };
+            _eventsDbSet.SetDbSetDataForAsync(new[] { @event });
+
+            var userOrg = new UserAndOrganizationDto { OrganizationId = 1, UserId = users.First().Id };
+            var editDetails = await _eventService.GetEventForEditingAsync(eventId, userOrg);
+
+            var editDto = new EditEventDto
+            {
+                Id = eventId.ToString(),
+                UserId = users.First().Id,
+                StartDate = @event.StartDate,
+                EndDate = @event.EndDate,
+                ImageName = "imageUrl",
+                Name = "Question-only event",
+                Location = "New location",
+                MaxParticipants = 15,
+                OrganizationId = 1,
+                Description = "desc",
+                Offices = new EventOfficesDto { OfficeNames = new List<string> { office.Name } },
+                RegistrationDeadlineDate = @event.RegistrationDeadline,
+                MaxOptions = editDetails.MaxOptions,
+                ResponsibleUserId = users.First().Id,
+                TypeId = eventTypes.Last().Id,
+                NewOptions = new List<NewEventOptionDto>(),
+                EditedOptions = editDetails.Options.Select(o => new EventOptionDto { Id = o.Id, Option = o.Option, Rule = o.Rule }),
+                Reminders = new List<EventReminderDto>()
+            };
+
+            Assert.DoesNotThrowAsync(async () => await _eventService.UpdateEventAsync(editDto));
+        }
+
+        // Question-owned options must never be hard-deleted through the legacy option edit path:
+        // once MapToEventEditDetailsDto stops leaking them into EditedOptions, a naive
+        // "anything not in EditedOptions gets removed" sweep would delete every question's
+        // options on the host's very next save. Only legacy (QuestionId == null) options may be
+        // removed here; question-owned rows belong solely to EventQuestionWriter.
+        [Test]
+        public async Task Should_Not_Remove_Question_Owned_Options_When_Editing_Event()
+        {
+            MockPermissionService(_permissionService);
+            var users = MockUsers();
+            var eventTypes = MockEventTypes();
+            var office = MockOffices().First();
+            var eventId = Guid.NewGuid();
+
+            var legacyOptionKept1 = new EventOption { Id = 1, Option = "Legacy kept 1", QuestionId = null };
+            var legacyOptionKept2 = new EventOption { Id = 2, Option = "Legacy kept 2", QuestionId = null };
+            var legacyOptionRemoved = new EventOption { Id = 3, Option = "Legacy removed", QuestionId = null };
+            var questionOption1 = new EventOption { Id = 101, Option = "Pizza", QuestionId = 5 };
+            var questionOption2 = new EventOption { Id = 102, Option = "Pasta", QuestionId = 5 };
+
+            var @event = new Event
+            {
+                Id = eventId,
+                StartDate = DateTime.UtcNow.AddDays(4),
+                EndDate = DateTime.UtcNow.AddDays(4),
+                Created = DateTime.UtcNow,
+                ResponsibleUserId = users.First().Id,
+                ResponsibleUser = users.First(),
+                EventRecurring = EventRecurrenceOptions.None,
+                ImageName = "imageUrl",
+                Name = "Dinner event",
+                Place = "City",
+                MaxParticipants = 15,
+                OrganizationId = 1,
+                Description = "desc",
+                EventOptions = new List<EventOption> { legacyOptionKept1, legacyOptionKept2, legacyOptionRemoved, questionOption1, questionOption2 },
+                EventParticipants = new List<EventParticipant>(),
+                Offices = $"[\"{office.Id}\"]",
+                RegistrationDeadline = DateTime.UtcNow,
+                MaxChoices = 1,
+                EventType = eventTypes.Last(),
+                EventTypeId = eventTypes.Last().Id,
+                Reminders = new List<EventReminder>()
+            };
+            _eventsDbSet.SetDbSetDataForAsync(new[] { @event });
+
+            var editDto = new EditEventDto
+            {
+                Id = eventId.ToString(),
+                UserId = users.First().Id,
+                StartDate = @event.StartDate,
+                EndDate = @event.EndDate,
+                ImageName = "imageUrl",
+                Name = "Dinner event",
+                Location = "New location",
+                MaxParticipants = 15,
+                OrganizationId = 1,
+                Description = "desc",
+                Offices = new EventOfficesDto { OfficeNames = new List<string> { office.Name } },
+                RegistrationDeadlineDate = @event.RegistrationDeadline,
+                MaxOptions = 1,
+                ResponsibleUserId = users.First().Id,
+                TypeId = eventTypes.Last().Id,
+                NewOptions = new List<NewEventOptionDto>(),
+                EditedOptions = new List<EventOptionDto>
+                {
+                    new EventOptionDto { Id = legacyOptionKept1.Id, Option = "Legacy kept 1 edited" },
+                    new EventOptionDto { Id = legacyOptionKept2.Id, Option = "Legacy kept 2 edited" }
+                },
+                Reminders = new List<EventReminderDto>()
+            };
+
+            await _eventService.UpdateEventAsync(editDto);
+
+            _eventOptionsDbSet.Received(1).Remove(legacyOptionRemoved);
+            _eventOptionsDbSet.DidNotReceive().Remove(questionOption1);
+            _eventOptionsDbSet.DidNotReceive().Remove(questionOption2);
+            _eventOptionsDbSet.DidNotReceive().Remove(legacyOptionKept1);
+            _eventOptionsDbSet.DidNotReceive().Remove(legacyOptionKept2);
+        }
+
         private List<EventType> MockEventTypes()
         {
             var types = new List<EventType>

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventCrudServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventCrudServiceTests.cs
@@ -68,6 +68,7 @@ namespace Shrooms.Premium.Tests.DomainService
             var eventValidationService = new EventValidationService(_systemClockMock);
             var officeMapService = Substitute.For<IOfficeMapService>();
             var markdownConverter = Substitute.For<IMarkdownConverter>();
+            var eventQuestionWriter = Substitute.For<IEventQuestionWriter>();
 
             _eventService = new EventService(
                 _uow,
@@ -78,7 +79,8 @@ namespace Shrooms.Premium.Tests.DomainService
                 _wallService,
                 markdownConverter,
                 officeMapService,
-                _systemClock);
+                _systemClock,
+                eventQuestionWriter);
         }
 
         [Test]

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventCrudServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventCrudServiceTests.cs
@@ -1195,6 +1195,7 @@ namespace Shrooms.Premium.Tests.DomainService
                     Description = "desc",
                     EventOptions = eventOptions,
                     EventParticipants = eventParticipants,
+                    EventQuestions = new List<EventQuestion>(),
                     Offices = "[\"1\"]",
                     StartDate = DateTime.UtcNow,
                     EndDate = DateTime.UtcNow,

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventListingServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventListingServiceTests.cs
@@ -188,7 +188,20 @@ namespace Shrooms.Premium.Tests.DomainService
         public async Task Should_Return_No_Chosen_Options_When_The_Caller_Has_Not_Joined()
         {
             var eventId = MockEventWithQuestions();
-            _eventParticipantsDbSet.SetDbSetDataForAsync(new List<EventParticipant>());
+            // Someone else's answers, and no row for the caller. Seeding an empty list here
+            // would make this test vacuous — MyChosenOptions already defaults to empty, so it
+            // would pass with no implementation at all. With another participant present it
+            // fails the moment the query stops filtering by user.
+            _eventParticipantsDbSet.SetDbSetDataForAsync(new List<EventParticipant>
+            {
+                new EventParticipant
+                {
+                    Id = 2,
+                    EventId = eventId,
+                    ApplicationUserId = "someoneElse",
+                    EventOptions = new List<EventOption> { new EventOption { Id = 51 } }
+                }
+            });
             var userOrg = new UserAndOrganizationDto { OrganizationId = 2, UserId = "testUser1" };
 
             var result = await _eventListingService.GetEventOptionsAsync(eventId, userOrg);

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventListingServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventListingServiceTests.cs
@@ -153,6 +153,50 @@ namespace Shrooms.Premium.Tests.DomainService
         }
 
         [Test]
+        public async Task Should_Return_My_Chosen_Options_For_The_Calling_User()
+        {
+            var eventId = MockEventWithQuestions();
+            _eventParticipantsDbSet.SetDbSetDataForAsync(new List<EventParticipant>
+            {
+                new EventParticipant
+                {
+                    Id = 1,
+                    EventId = eventId,
+                    ApplicationUserId = "testUser1",
+                    EventOptions = new List<EventOption>
+                    {
+                        new EventOption { Id = 50 },
+                        new EventOption { Id = 40 }
+                    }
+                },
+                new EventParticipant
+                {
+                    Id = 2,
+                    EventId = eventId,
+                    ApplicationUserId = "someoneElse",
+                    EventOptions = new List<EventOption> { new EventOption { Id = 51 } }
+                }
+            });
+            var userOrg = new UserAndOrganizationDto { OrganizationId = 2, UserId = "testUser1" };
+
+            var result = await _eventListingService.GetEventOptionsAsync(eventId, userOrg);
+
+            Assert.That(result.MyChosenOptions, Is.EquivalentTo(new[] { 40, 50 }));
+        }
+
+        [Test]
+        public async Task Should_Return_No_Chosen_Options_When_The_Caller_Has_Not_Joined()
+        {
+            var eventId = MockEventWithQuestions();
+            _eventParticipantsDbSet.SetDbSetDataForAsync(new List<EventParticipant>());
+            var userOrg = new UserAndOrganizationDto { OrganizationId = 2, UserId = "testUser1" };
+
+            var result = await _eventListingService.GetEventOptionsAsync(eventId, userOrg);
+
+            Assert.That(result.MyChosenOptions, Is.Empty);
+        }
+
+        [Test]
         public void Should_Throw_If_Event_Deadline_Is_Greater_Than_Start_Date()
         {
             var deadlineDate = DateTime.Parse("2016-05-01");

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventListingServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventListingServiceTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using Shrooms.Contracts.DAL;
 using Shrooms.Contracts.DataTransferObjects;
+using Shrooms.Contracts.Enums;
 using Shrooms.Contracts.Infrastructure;
 using Shrooms.DataLayer.EntityModels.Models;
 using Shrooms.DataLayer.EntityModels.Models.Events;
@@ -119,6 +120,36 @@ namespace Shrooms.Premium.Tests.DomainService
             ClassicAssert.AreEqual(result.Options.Count(), 2);
             ClassicAssert.AreEqual(result.Options.First(o => o.Id == 4).Option, "Option1");
             ClassicAssert.AreEqual(result.Options.First(o => o.Id == 5).Option, "Option2");
+        }
+
+        [Test]
+        public async Task Should_Keep_Question_Options_Out_Of_The_Legacy_Option_List()
+        {
+            var eventId = MockEventWithQuestions();
+            var userOrg = new UserAndOrganizationDto { OrganizationId = 2, UserId = "testUser1" };
+
+            var result = await _eventListingService.GetEventOptionsAsync(eventId, userOrg);
+
+            Assert.That(result.Options.Select(o => o.Id), Is.EquivalentTo(new[] { 40 }));
+        }
+
+        [Test]
+        public async Task Should_Return_Questions_And_Their_Options_In_Order()
+        {
+            var eventId = MockEventWithQuestions();
+            var userOrg = new UserAndOrganizationDto { OrganizationId = 2, UserId = "testUser1" };
+
+            var result = await _eventListingService.GetEventOptionsAsync(eventId, userOrg);
+
+            var questions = result.Questions.ToList();
+            Assert.That(questions.Select(q => q.Id), Is.EqualTo(new int?[] { 5, 6 }));
+            Assert.That(questions[0].Title, Is.EqualTo("Pick your dish"));
+            Assert.That(questions[0].SelectType, Is.EqualTo(EventQuestionSelectType.Single));
+            Assert.That(questions[0].IsRequired, Is.True);
+            Assert.That(questions[0].ShowIfOptionId, Is.Null);
+            Assert.That(questions[0].Options.Select(o => o.Id), Is.EqualTo(new int?[] { 50, 51 }));
+            Assert.That(questions[0].Options[0].Name, Is.EqualTo("Pasta"));
+            Assert.That(questions[1].ShowIfOptionId, Is.EqualTo(51));
         }
 
         [Test]
@@ -1458,7 +1489,8 @@ namespace Shrooms.Premium.Tests.DomainService
                     },
                     EventParticipants = new List<EventParticipant>(),
                     EventTypeId = 1,
-                    EventOptions = options1
+                    EventOptions = options1,
+                    EventQuestions = new List<EventQuestion>()
                 },
                 new Event
                 {
@@ -1475,13 +1507,74 @@ namespace Shrooms.Premium.Tests.DomainService
                     },
                     EventParticipants = new List<EventParticipant>(),
                     EventTypeId = 1,
-                    EventOptions = options2
+                    EventOptions = options2,
+                    EventQuestions = new List<EventQuestion>()
                 }
             };
 
             _eventsDbSet.SetDbSetDataForAsync(events.AsQueryable());
 
             return guids;
+        }
+
+        private Guid MockEventWithQuestions()
+        {
+            var eventId = Guid.NewGuid();
+
+            var legacyOption = new EventOption { Id = 40, EventId = eventId, Option = "Vegetarian", QuestionId = null };
+
+            var dishOptions = new List<EventOption>
+            {
+                new EventOption { Id = 51, EventId = eventId, Option = "Pizza", QuestionId = 5, Order = 1 },
+                new EventOption { Id = 50, EventId = eventId, Option = "Pasta", QuestionId = 5, Order = 0 }
+            };
+
+            var questions = new List<EventQuestion>
+            {
+                new EventQuestion
+                {
+                    Id = 6,
+                    EventId = eventId,
+                    Title = "Which pizza?",
+                    Order = 1,
+                    SelectType = EventQuestionSelectType.Single,
+                    IsRequired = false,
+                    ShowIfOptionId = 51,
+                    Options = new List<EventOption>()
+                },
+                new EventQuestion
+                {
+                    Id = 5,
+                    EventId = eventId,
+                    Title = "Pick your dish",
+                    Order = 0,
+                    SelectType = EventQuestionSelectType.Single,
+                    IsRequired = true,
+                    ShowIfOptionId = null,
+                    Options = dishOptions
+                }
+            };
+
+            var events = new List<Event>
+            {
+                new Event
+                {
+                    Id = eventId,
+                    MaxChoices = 0,
+                    MaxParticipants = 20,
+                    OrganizationId = 2,
+                    Name = "Question event",
+                    EventTypeId = 1,
+                    EventType = new EventType { Id = 1, Name = "test type", IsSingleJoin = false },
+                    EventParticipants = new List<EventParticipant>(),
+                    EventOptions = new List<EventOption> { legacyOption, dishOptions[0], dishOptions[1] },
+                    EventQuestions = questions
+                }
+            };
+
+            _eventsDbSet.SetDbSetDataForAsync(events.AsQueryable());
+
+            return eventId;
         }
 
         private IList<Event> MockEventReportParticipantsTest()

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventServiceTests.cs
@@ -147,6 +147,80 @@ namespace Shrooms.Premium.Tests.DomainService
             Assert.That(questions[1].ShowIfOptionId, Is.EqualTo(91));
         }
 
+        // Regression test: MapToEventEditDetailsDto used to project every EventOption into the
+        // flat Options list, including ones owned by a question. That leaked question options
+        // into the edit payload's editedOptions on the client. Only legacy (QuestionId == null)
+        // options belong in Options; question-owned options are exposed solely under Questions.
+        [Test]
+        public async Task Should_Only_Return_Legacy_Options_In_Flat_Options_List_When_Editing()
+        {
+            var eventId = MockEventForEditingWithLegacyAndQuestionOptions();
+            var userOrg = new UserAndOrganizationDto { OrganizationId = 2, UserId = "testUser1" };
+
+            var result = await _eventService.GetEventForEditingAsync(eventId, userOrg);
+
+            var flatOptions = result.Options.ToList();
+            Assert.That(flatOptions, Has.Count.EqualTo(1));
+            Assert.That(flatOptions[0].Id, Is.EqualTo(80));
+            Assert.That(flatOptions[0].Option, Is.EqualTo("Legacy option"));
+
+            var questions = result.Questions.ToList();
+            Assert.That(questions, Has.Count.EqualTo(1));
+            Assert.That(questions[0].Options.Select(o => o.Id), Is.EquivalentTo(new int?[] { 90, 91 }));
+        }
+
+        private Guid MockEventForEditingWithLegacyAndQuestionOptions()
+        {
+            var eventId = Guid.NewGuid();
+            var responsibleUser = new ApplicationUser
+            {
+                Id = "responsibleUser1",
+                FirstName = "user1f",
+                LastName = "user1l"
+            };
+
+            var legacyOption = new EventOption { Id = 80, EventId = eventId, Option = "Legacy option", QuestionId = null, Order = 0 };
+
+            var questionOptions = new List<EventOption>
+            {
+                new EventOption { Id = 90, EventId = eventId, Option = "Pasta", QuestionId = 5, Order = 0 },
+                new EventOption { Id = 91, EventId = eventId, Option = "Pizza", QuestionId = 5, Order = 1 }
+            };
+
+            var questions = new List<EventQuestion>
+            {
+                new EventQuestion
+                {
+                    Id = 5,
+                    EventId = eventId,
+                    Title = "Pick your dish",
+                    Order = 0,
+                    SelectType = EventQuestionSelectType.Single,
+                    IsRequired = true,
+                    ShowIfOptionId = null,
+                    Options = questionOptions
+                }
+            };
+
+            var events = new List<Event>
+            {
+                new Event
+                {
+                    Id = eventId,
+                    OrganizationId = 2,
+                    ResponsibleUser = responsibleUser,
+                    ResponsibleUserId = responsibleUser.Id,
+                    Reminders = new List<EventReminder>(),
+                    EventOptions = new List<EventOption> { legacyOption, questionOptions[0], questionOptions[1] },
+                    EventQuestions = questions
+                }
+            };
+
+            _eventsDbSet.SetDbSetDataForAsync(events.AsQueryable());
+
+            return eventId;
+        }
+
         private Guid MockEventForEditingWithQuestions()
         {
             var eventId = Guid.NewGuid();

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventServiceTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using Shrooms.Contracts.DAL;
 using Shrooms.Contracts.DataTransferObjects;
+using Shrooms.Contracts.Enums;
 using Shrooms.Contracts.Infrastructure;
 using Shrooms.DataLayer.EntityModels.Models;
 using Shrooms.DataLayer.EntityModels.Models.Events;
@@ -18,6 +19,7 @@ using Shrooms.Premium.Domain.Services.OfficeMap;
 using Shrooms.Tests.Extensions;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using System.Threading.Tasks;
 
@@ -123,6 +125,95 @@ namespace Shrooms.Premium.Tests.DomainService
 
             ClassicAssert.AreEqual(result.Name, @event.Name);
             ClassicAssert.AreEqual(result.HostUserId, @event.ResponsibleUser.Id);
+        }
+
+        [Test]
+        public async Task Should_Return_The_Question_Tree_For_Editing()
+        {
+            var eventId = MockEventForEditingWithQuestions();
+            var userOrg = new UserAndOrganizationDto { OrganizationId = 2, UserId = "testUser1" };
+
+            var result = await _eventService.GetEventForEditingAsync(eventId, userOrg);
+
+            var questions = result.Questions.ToList();
+            Assert.That(questions, Has.Count.EqualTo(2));
+            Assert.That(questions[0].Id, Is.EqualTo(5));
+            Assert.That(questions[0].Title, Is.EqualTo("Pick your dish"));
+            Assert.That(questions[0].SelectType, Is.EqualTo(EventQuestionSelectType.Single));
+            Assert.That(questions[0].IsRequired, Is.True);
+            Assert.That(questions[0].ShowIfOptionId, Is.Null);
+            Assert.That(questions[0].Options.Select(o => o.Id), Is.EqualTo(new int?[] { 90, 91 }));
+            Assert.That(questions[0].Options[0].Name, Is.EqualTo("Pasta"));
+            Assert.That(questions[1].ShowIfOptionId, Is.EqualTo(91));
+        }
+
+        private Guid MockEventForEditingWithQuestions()
+        {
+            var eventId = Guid.NewGuid();
+            var responsibleUser = new ApplicationUser
+            {
+                Id = "responsibleUser1",
+                FirstName = "user1f",
+                LastName = "user1l"
+            };
+
+            // Seeded out of order (91 before 90) so the Options OrderBy is genuinely exercised.
+            var dishOptions = new List<EventOption>
+            {
+                new EventOption { Id = 91, EventId = eventId, Option = "Pizza", QuestionId = 5, Order = 1 },
+                new EventOption { Id = 90, EventId = eventId, Option = "Pasta", QuestionId = 5, Order = 0 }
+            };
+
+            var pizzaOptions = new List<EventOption>
+            {
+                new EventOption { Id = 92, EventId = eventId, Option = "Margherita", QuestionId = 6, Order = 0 }
+            };
+
+            // Seeded out of order (question 6 before question 5) so the Questions OrderBy is
+            // genuinely exercised.
+            var questions = new List<EventQuestion>
+            {
+                new EventQuestion
+                {
+                    Id = 6,
+                    EventId = eventId,
+                    Title = "Which pizza?",
+                    Order = 1,
+                    SelectType = EventQuestionSelectType.Single,
+                    IsRequired = true,
+                    ShowIfOptionId = 91,
+                    Options = pizzaOptions
+                },
+                new EventQuestion
+                {
+                    Id = 5,
+                    EventId = eventId,
+                    Title = "Pick your dish",
+                    Order = 0,
+                    SelectType = EventQuestionSelectType.Single,
+                    IsRequired = true,
+                    ShowIfOptionId = null,
+                    Options = dishOptions
+                }
+            };
+
+            var events = new List<Event>
+            {
+                new Event
+                {
+                    Id = eventId,
+                    OrganizationId = 2,
+                    ResponsibleUser = responsibleUser,
+                    ResponsibleUserId = responsibleUser.Id,
+                    Reminders = new List<EventReminder>(),
+                    EventOptions = new List<EventOption> { dishOptions[0], dishOptions[1], pizzaOptions[0] },
+                    EventQuestions = questions
+                }
+            };
+
+            _eventsDbSet.SetDbSetDataForAsync(events.AsQueryable());
+
+            return eventId;
         }
     }
 }

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventServiceTests.cs
@@ -56,6 +56,7 @@ namespace Shrooms.Premium.Tests.DomainService
             var eventParticipationService = Substitute.For<IEventParticipationService>();
             var eventUtilitiesService = Substitute.For<IEventUtilitiesService>();
             var markdownConverter = Substitute.For<IMarkdownConverter>();
+            var eventQuestionWriter = Substitute.For<IEventQuestionWriter>();
 
             _eventService = new EventService(
                 _uow,
@@ -66,7 +67,8 @@ namespace Shrooms.Premium.Tests.DomainService
                 _wallService,
                 markdownConverter,
                 _officeMapService,
-                _systemClock);
+                _systemClock,
+                eventQuestionWriter);
         }
 
         [TestCase(1)]

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventParticipantServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventParticipantServiceTests.cs
@@ -798,13 +798,13 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
             var chosenOptionIds = new List<int> { -9999 };
             var dto = new EventChangeOptionsDto { EventId = guid, OrganizationId = 2, ChosenOptions = chosenOptionIds };
 
-            // The answer validator now runs ahead of CheckIfProvidedOptionsAreValid, so an unknown
-            // option comes back as the structured payload naming it rather than a bare code.
-            var ex = Assert.ThrowsAsync<EventAnswersInvalidException>(
-                async () => await _eventParticipationService.UpdateSelectedOptionsAsync(dto));
+            _eventValidationServiceMock
+                .When(x => x.CheckIfProvidedOptionsAreValid(Arg.Is<IEnumerable<int>>(a => a.SequenceEqual(chosenOptionIds)), Arg.Is<ICollection<EventOption>>(a => a.Count == 0)))
+                .Do(_ => throw new EventException(PremiumErrorCodes.EventRegistrationDeadlineIsExpired));
 
-            Assert.That(ex.Errors.Single().Reason, Is.EqualTo(EventAnswerErrorReason.UnknownOption));
-            Assert.That(ex.Errors.Single().OptionId, Is.EqualTo(-9999));
+            // CheckIfProvidedOptionsAreValid still owns the unknown-option rejection, ahead of the
+            // answer validator: it answers with code 215, which the web client has a message for.
+            Assert.ThrowsAsync<EventException>(async () => await _eventParticipationService.UpdateSelectedOptionsAsync(dto), PremiumErrorCodes.EventNoSuchOptionsCode);
         }
 
         [Test]

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventParticipantServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventParticipantServiceTests.cs
@@ -44,6 +44,8 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
 
         private IAsyncRunner _asyncRunner;
 
+        private IEventAnswerValidator _eventAnswerValidator;
+
         [SetUp]
         public void TestInitializer()
         {
@@ -69,6 +71,7 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
             MockRoleService(roleService);
             _wallService = Substitute.For<IWallService>();
             _asyncRunner = Substitute.For<IAsyncRunner>();
+            _eventAnswerValidator = new EventAnswerValidator();
 
             _eventParticipationService =
                 new EventParticipationService(
@@ -78,7 +81,8 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
                     permissionService,
                     _eventValidationServiceMock,
                     _wallService,
-                    _asyncRunner);
+                    _asyncRunner,
+                    _eventAnswerValidator);
         }
 
         [Test]
@@ -185,7 +189,8 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
                 Substitute.For<IPermissionService>(),
                 _eventValidationService,
                 _wallService,
-                _asyncRunner);
+                _asyncRunner,
+                _eventAnswerValidator);
 
             var eventJoinDto = new EventJoinDto
             {
@@ -200,6 +205,84 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
             };
 
             Assert.DoesNotThrowAsync(async () => await _eventParticipationService.JoinAsync(eventJoinDto));
+        }
+
+        [Test]
+        public void Should_Reject_A_Join_That_Skips_A_Required_Question()
+        {
+            var eventId = MockEventWithRequiredQuestion();
+            var eventJoinDto = new EventJoinDto
+            {
+                ChosenOptions = new List<int>(),
+                EventId = eventId,
+                ParticipantIds = new List<string> { "user1" },
+                UserId = "user1",
+                OrganizationId = 2,
+                AttendStatus = AttendingStatus.Attending
+            };
+
+            var ex = Assert.ThrowsAsync<EventAnswersInvalidException>(
+                async () => await _eventParticipationService.JoinAsync(eventJoinDto));
+
+            Assert.That(ex.Errors.Select(e => e.Reason),
+                Is.EquivalentTo(new[] { EventAnswerErrorReason.RequiredAnswerMissing }));
+        }
+
+        [Test]
+        public void Should_Reject_An_Answer_For_A_Hidden_Question()
+        {
+            var eventId = MockEventWithRequiredQuestion();
+            // 92 belongs to the conditional question, whose trigger (91) was not chosen.
+            var eventJoinDto = new EventJoinDto
+            {
+                ChosenOptions = new List<int> { 90, 92 },
+                EventId = eventId,
+                ParticipantIds = new List<string> { "user1" },
+                UserId = "user1",
+                OrganizationId = 2,
+                AttendStatus = AttendingStatus.Attending
+            };
+
+            var ex = Assert.ThrowsAsync<EventAnswersInvalidException>(
+                async () => await _eventParticipationService.JoinAsync(eventJoinDto));
+
+            Assert.That(ex.Errors.Select(e => e.Reason),
+                Is.EquivalentTo(new[] { EventAnswerErrorReason.AnswerForHiddenQuestion }));
+        }
+
+        [Test]
+        public void Should_Accept_A_Join_That_Answers_Every_Reachable_Question()
+        {
+            var eventId = MockEventWithRequiredQuestion();
+            var eventJoinDto = new EventJoinDto
+            {
+                ChosenOptions = new List<int> { 91, 92 },
+                EventId = eventId,
+                ParticipantIds = new List<string> { "user1" },
+                UserId = "user1",
+                OrganizationId = 2,
+                AttendStatus = AttendingStatus.Attending
+            };
+
+            Assert.DoesNotThrowAsync(async () => await _eventParticipationService.JoinAsync(eventJoinDto));
+        }
+
+        [Test]
+        public void Should_Validate_Answers_When_A_Host_Adds_Colleagues()
+        {
+            var eventId = MockEventWithRequiredQuestion();
+            var eventJoinDto = new EventJoinDto
+            {
+                ChosenOptions = new List<int>(),
+                EventId = eventId,
+                ParticipantIds = new List<string> { "user1", "user2" },
+                UserId = "host1",
+                OrganizationId = 2,
+                AttendStatus = AttendingStatus.Attending
+            };
+
+            Assert.ThrowsAsync<EventAnswersInvalidException>(
+                async () => await _eventParticipationService.AddColleagueAsync(eventJoinDto));
         }
 
         [Test]
@@ -1434,6 +1517,7 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
                     EndDate = DateTime.Parse("2016-04-06"),
                     RegistrationDeadline = DateTime.Parse("2016-04-05"),
                     EventOptions = new List<EventOption>(),
+                    EventQuestions = new List<EventQuestion>(),
                     Id = guid,
                     MaxChoices = 0,
                     MaxParticipants = 20,
@@ -1519,6 +1603,7 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
                             Rule = OptionRules.IgnoreSingleJoin
                         }
                     },
+                    EventQuestions = new List<EventQuestion>(),
                     Id = guid,
                     MaxChoices = 1,
                     MaxParticipants = 20,

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventParticipantServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventParticipantServiceTests.cs
@@ -798,11 +798,13 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
             var chosenOptionIds = new List<int> { -9999 };
             var dto = new EventChangeOptionsDto { EventId = guid, OrganizationId = 2, ChosenOptions = chosenOptionIds };
 
-            _eventValidationServiceMock
-                .When(x => x.CheckIfProvidedOptionsAreValid(Arg.Is<IEnumerable<int>>(a => a.SequenceEqual(chosenOptionIds)), Arg.Is<ICollection<EventOption>>(a => a.Count == 0)))
-                .Do(_ => throw new EventException(PremiumErrorCodes.EventRegistrationDeadlineIsExpired));
+            // The answer validator now runs ahead of CheckIfProvidedOptionsAreValid, so an unknown
+            // option comes back as the structured payload naming it rather than a bare code.
+            var ex = Assert.ThrowsAsync<EventAnswersInvalidException>(
+                async () => await _eventParticipationService.UpdateSelectedOptionsAsync(dto));
 
-            Assert.ThrowsAsync<EventException>(async () => await _eventParticipationService.UpdateSelectedOptionsAsync(dto), PremiumErrorCodes.EventNoSuchOptionsCode);
+            Assert.That(ex.Errors.Single().Reason, Is.EqualTo(EventAnswerErrorReason.UnknownOption));
+            Assert.That(ex.Errors.Single().OptionId, Is.EqualTo(-9999));
         }
 
         [Test]

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventParticipantServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventParticipantServiceTests.cs
@@ -172,6 +172,37 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
         }
 
         [Test]
+        public void Should_Let_A_Question_Only_Event_Be_Joined_With_Answers()
+        {
+            var eventId = MockEventWithRequiredQuestion();
+
+            // Use the real EventValidationService here (not the substitute) so the choice checks
+            // actually run instead of being no-ops.
+            _eventParticipationService = new EventParticipationService(
+                _uow2,
+                _systemClockMock,
+                Substitute.For<IRoleService>(),
+                Substitute.For<IPermissionService>(),
+                _eventValidationService,
+                _wallService,
+                _asyncRunner);
+
+            var eventJoinDto = new EventJoinDto
+            {
+                // Answers q5 with Pasta. q6 is conditional on Pizza, so it stays hidden and
+                // unanswered — a valid submission that today trips the MaxChoices check.
+                ChosenOptions = new List<int> { 90 },
+                EventId = eventId,
+                ParticipantIds = new List<string> { "user1" },
+                UserId = "user1",
+                OrganizationId = 2,
+                AttendStatus = AttendingStatus.Attending
+            };
+
+            Assert.DoesNotThrowAsync(async () => await _eventParticipationService.JoinAsync(eventJoinDto));
+        }
+
+        [Test]
         public void Should_Throw_If_Joining_Event_Is_Expired()
         {
             _systemClockMock.UtcNow.Returns(DateTime.Parse("2016-06-21"));
@@ -1548,6 +1579,101 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
             _eventParticipantsDbSet.SetDbSetDataForAsync(participants.AsQueryable());
             _eventsDbSet.SetDbSetDataForAsync(events.AsQueryable());
             return guid;
+        }
+
+        /// <summary>
+        /// q5 "Pick your dish" (required, single, always shown): 90 Pasta, 91 Pizza.
+        /// q6 "Which pizza?"   (required, single, shown if 91):   92 Margherita.
+        /// MaxChoices is 0 — every option belongs to a question, so nothing counts as a legacy choice.
+        /// </summary>
+        private Guid MockEventWithRequiredQuestion(bool withAttendingUser1 = false)
+        {
+            var eventId = Guid.NewGuid();
+            _systemClockMock.UtcNow.Returns(DateTime.Parse("2026-01-01"));
+
+            var dishOptions = new List<EventOption>
+            {
+                new EventOption { Id = 90, EventId = eventId, Option = "Pasta", QuestionId = 5, Order = 0 },
+                new EventOption { Id = 91, EventId = eventId, Option = "Pizza", QuestionId = 5, Order = 1 }
+            };
+
+            var pizzaOptions = new List<EventOption>
+            {
+                new EventOption { Id = 92, EventId = eventId, Option = "Margherita", QuestionId = 6, Order = 0 }
+            };
+
+            var participants = withAttendingUser1
+                ? new List<EventParticipant>
+                {
+                    new EventParticipant
+                    {
+                        Id = 1,
+                        EventId = eventId,
+                        ApplicationUserId = "user1",
+                        AttendStatus = (int)AttendingStatus.Attending,
+                        EventOptions = new List<EventOption>()
+                    }
+                }
+                : new List<EventParticipant>();
+
+            var events = new List<Event>
+            {
+                new Event
+                {
+                    Id = eventId,
+                    OrganizationId = 2,
+                    Name = "Question event",
+                    MaxChoices = 0,
+                    MaxParticipants = 20,
+                    MaxVirtualParticipants = 0,
+                    StartDate = DateTime.Parse("2026-06-01"),
+                    EndDate = DateTime.Parse("2026-06-02"),
+                    RegistrationDeadline = DateTime.Parse("2026-05-01"),
+                    AllowMaybeGoing = true,
+                    AllowNotGoing = true,
+                    ResponsibleUserId = "host1",
+                    EventTypeId = 1,
+                    EventType = new EventType { Id = 1, Name = "test type", IsSingleJoin = false },
+                    EventParticipants = participants,
+                    EventOptions = dishOptions.Concat(pizzaOptions).ToList(),
+                    EventQuestions = new List<EventQuestion>
+                    {
+                        new EventQuestion
+                        {
+                            Id = 5,
+                            EventId = eventId,
+                            Title = "Pick your dish",
+                            Order = 0,
+                            SelectType = EventQuestionSelectType.Single,
+                            IsRequired = true,
+                            ShowIfOptionId = null,
+                            Options = dishOptions
+                        },
+                        new EventQuestion
+                        {
+                            Id = 6,
+                            EventId = eventId,
+                            Title = "Which pizza?",
+                            Order = 1,
+                            SelectType = EventQuestionSelectType.Single,
+                            IsRequired = true,
+                            ShowIfOptionId = 91,
+                            Options = pizzaOptions
+                        }
+                    }
+                }
+            };
+
+            _eventsDbSet.SetDbSetDataForAsync(events.AsQueryable());
+            _eventParticipantsDbSet.SetDbSetDataForAsync(participants.AsQueryable());
+            _usersDbSet.SetDbSetDataForAsync(new List<ApplicationUser>
+            {
+                new ApplicationUser { Id = "user1", OrganizationId = 2 },
+                new ApplicationUser { Id = "user2", OrganizationId = 2 },
+                new ApplicationUser { Id = "host1", OrganizationId = 2 }
+            });
+
+            return eventId;
         }
 
         private void MockUsers()

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventParticipantServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventParticipantServiceTests.cs
@@ -326,11 +326,35 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
             {
                 EventId = eventId,
                 ChosenOptions = new List<int>(),
+
+                // An empty Answers array is the caller saying "my answers are: none", which is what
+                // puts the answer rules in play. Omitting it means "leave my answers alone".
+                Answers = new List<int>(),
                 UserId = "user1",
                 OrganizationId = 2
             };
 
             Assert.ThrowsAsync<EventAnswersInvalidException>(
+                async () => await _eventParticipationService.UpdateSelectedOptionsAsync(changeOptionsDto));
+        }
+
+        [Test]
+        public void Should_Not_Enforce_Answers_When_A_Legacy_Payload_Carries_None()
+        {
+            // The shipped AngularJS client posts flat options only. Enforcing answers against what
+            // is already stored would leave a participant unable to change options at all once a
+            // host adds a required question to a live event.
+            var eventId = MockEventWithRequiredQuestion(withAttendingUser1: true);
+
+            var changeOptionsDto = new EventChangeOptionsDto
+            {
+                EventId = eventId,
+                ChosenOptions = new List<int>(),
+                UserId = "user1",
+                OrganizationId = 2
+            };
+
+            Assert.DoesNotThrowAsync(
                 async () => await _eventParticipationService.UpdateSelectedOptionsAsync(changeOptionsDto));
         }
 

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventParticipantServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventParticipantServiceTests.cs
@@ -208,6 +208,38 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
         }
 
         [Test]
+        public void Should_Let_A_Mixed_Event_Be_Joined_With_A_Legacy_IgnoreSingleJoin_Option_And_A_Question_Answer()
+        {
+            var eventId = MockEventWithLegacyIgnoreSingleJoinOptionAndQuestion();
+
+            // Use the real EventValidationService here (not the substitute) so the choice checks
+            // actually run instead of being no-ops.
+            _eventParticipationService = new EventParticipationService(
+                _uow2,
+                _systemClockMock,
+                Substitute.For<IRoleService>(),
+                Substitute.For<IPermissionService>(),
+                _eventValidationService,
+                _wallService,
+                _asyncRunner,
+                _eventAnswerValidator);
+
+            var eventJoinDto = new EventJoinDto
+            {
+                // Option 10 is the legacy IgnoreSingleJoin option; 90 is the question answer.
+                // Picking both must not trip CheckIfSingleChoiceSelectedWithRule.
+                ChosenOptions = new List<int> { 10, 90 },
+                EventId = eventId,
+                ParticipantIds = new List<string> { "user1" },
+                UserId = "user1",
+                OrganizationId = 2,
+                AttendStatus = AttendingStatus.Attending
+            };
+
+            Assert.DoesNotThrowAsync(async () => await _eventParticipationService.JoinAsync(eventJoinDto));
+        }
+
+        [Test]
         public void Should_Reject_A_Join_That_Skips_A_Required_Question()
         {
             var eventId = MockEventWithRequiredQuestion();
@@ -288,21 +320,7 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
         [Test]
         public void Should_Reject_Edited_Choices_That_Skip_A_Required_Question()
         {
-            // withAttendingUser1: UpdateSelectedOptionsAsync runs CheckIfUserParticipatesInEvent
-            // against a participant list projected to attending statuses only, so without this the
-            // test would fail on participation rather than on the answers.
-            var eventId = MockEventWithRequiredQuestion(withAttendingUser1: true);
-            _eventParticipantsDbSet.SetDbSetDataForAsync(new List<EventParticipant>
-            {
-                new EventParticipant
-                {
-                    Id = 1,
-                    EventId = eventId,
-                    ApplicationUserId = "user1",
-                    AttendStatus = (int)AttendingStatus.Attending,
-                    EventOptions = new List<EventOption>()
-                }
-            });
+            var eventId = MockEventWithRequiredQuestion();
 
             var changeOptionsDto = new EventChangeOptionsDto
             {
@@ -781,7 +799,7 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
             var dto = new EventChangeOptionsDto { EventId = guid, OrganizationId = 2, ChosenOptions = chosenOptionIds };
 
             _eventValidationServiceMock
-                .When(x => x.CheckIfProvidedOptionsAreValid(chosenOptionIds, Arg.Is<ICollection<EventOption>>(a => a.Count == 0)))
+                .When(x => x.CheckIfProvidedOptionsAreValid(Arg.Is<IEnumerable<int>>(a => a.SequenceEqual(chosenOptionIds)), Arg.Is<ICollection<EventOption>>(a => a.Count == 0)))
                 .Do(_ => throw new EventException(PremiumErrorCodes.EventRegistrationDeadlineIsExpired));
 
             Assert.ThrowsAsync<EventException>(async () => await _eventParticipationService.UpdateSelectedOptionsAsync(dto), PremiumErrorCodes.EventNoSuchOptionsCode);
@@ -1787,6 +1805,74 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
                 new ApplicationUser { Id = "user1", OrganizationId = 2 },
                 new ApplicationUser { Id = "user2", OrganizationId = 2 },
                 new ApplicationUser { Id = "host1", OrganizationId = 2 }
+            });
+
+            return eventId;
+        }
+
+        /// <summary>
+        /// Mixed event: one legacy option (10, no QuestionId) carrying <see cref="OptionRules.IgnoreSingleJoin"/>,
+        /// plus a required question (5) with its own option (90). MaxChoices is 1, counting the legacy
+        /// option only. Exercises FIX 1: question answers must not be counted by
+        /// CheckIfSingleChoiceSelectedWithRule alongside the legacy IgnoreSingleJoin option.
+        /// </summary>
+        private Guid MockEventWithLegacyIgnoreSingleJoinOptionAndQuestion()
+        {
+            var eventId = Guid.NewGuid();
+            _systemClockMock.UtcNow.Returns(DateTime.Parse("2026-01-01"));
+
+            var legacyOptions = new List<EventOption>
+            {
+                new EventOption { Id = 10, EventId = eventId, Option = "Legacy", QuestionId = null, Rule = OptionRules.IgnoreSingleJoin, Order = 0 }
+            };
+
+            var questionOptions = new List<EventOption>
+            {
+                new EventOption { Id = 90, EventId = eventId, Option = "QOption", QuestionId = 5, Order = 0 }
+            };
+
+            var events = new List<Event>
+            {
+                new Event
+                {
+                    Id = eventId,
+                    OrganizationId = 2,
+                    Name = "Mixed event",
+                    MaxChoices = 1,
+                    MaxParticipants = 20,
+                    MaxVirtualParticipants = 0,
+                    StartDate = DateTime.Parse("2026-06-01"),
+                    EndDate = DateTime.Parse("2026-06-02"),
+                    RegistrationDeadline = DateTime.Parse("2026-05-01"),
+                    AllowMaybeGoing = true,
+                    AllowNotGoing = true,
+                    ResponsibleUserId = "host1",
+                    EventTypeId = 1,
+                    EventType = new EventType { Id = 1, Name = "test type", IsSingleJoin = false },
+                    EventParticipants = new List<EventParticipant>(),
+                    EventOptions = legacyOptions.Concat(questionOptions).ToList(),
+                    EventQuestions = new List<EventQuestion>
+                    {
+                        new EventQuestion
+                        {
+                            Id = 5,
+                            EventId = eventId,
+                            Title = "Pick one",
+                            Order = 0,
+                            SelectType = EventQuestionSelectType.Single,
+                            IsRequired = true,
+                            ShowIfOptionId = null,
+                            Options = questionOptions
+                        }
+                    }
+                }
+            };
+
+            _eventsDbSet.SetDbSetDataForAsync(events.AsQueryable());
+            _eventParticipantsDbSet.SetDbSetDataForAsync(new List<EventParticipant>().AsQueryable());
+            _usersDbSet.SetDbSetDataForAsync(new List<ApplicationUser>
+            {
+                new ApplicationUser { Id = "user1", OrganizationId = 2 }
             });
 
             return eventId;

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventParticipantServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventParticipantServiceTests.cs
@@ -286,6 +286,37 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
         }
 
         [Test]
+        public void Should_Reject_Edited_Choices_That_Skip_A_Required_Question()
+        {
+            // withAttendingUser1: UpdateSelectedOptionsAsync runs CheckIfUserParticipatesInEvent
+            // against a participant list projected to attending statuses only, so without this the
+            // test would fail on participation rather than on the answers.
+            var eventId = MockEventWithRequiredQuestion(withAttendingUser1: true);
+            _eventParticipantsDbSet.SetDbSetDataForAsync(new List<EventParticipant>
+            {
+                new EventParticipant
+                {
+                    Id = 1,
+                    EventId = eventId,
+                    ApplicationUserId = "user1",
+                    AttendStatus = (int)AttendingStatus.Attending,
+                    EventOptions = new List<EventOption>()
+                }
+            });
+
+            var changeOptionsDto = new EventChangeOptionsDto
+            {
+                EventId = eventId,
+                ChosenOptions = new List<int>(),
+                UserId = "user1",
+                OrganizationId = 2
+            };
+
+            Assert.ThrowsAsync<EventAnswersInvalidException>(
+                async () => await _eventParticipationService.UpdateSelectedOptionsAsync(changeOptionsDto));
+        }
+
+        [Test]
         public void Should_Throw_If_Joining_Event_Is_Expired()
         {
             _systemClockMock.UtcNow.Returns(DateTime.Parse("2016-06-21"));

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventQuestionWriterTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventQuestionWriterTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using NUnit.Framework;
+using Shrooms.Contracts.DAL;
+using Shrooms.Contracts.Enums;
+using Shrooms.DataLayer.EntityModels.Models.Events;
+using Shrooms.Premium.DataTransferObjects.Models.Events;
+using Shrooms.Premium.Domain.DomainExceptions.Event;
+using Shrooms.Premium.Domain.DomainServiceValidators.Events;
+using Shrooms.Premium.Domain.Services.Events;
+using Shrooms.Tests.Extensions;
+
+namespace Shrooms.Premium.Tests.DomainService.EventServices
+{
+    public class EventQuestionWriterTests
+    {
+        private IUnitOfWork2 _uow;
+        private IEventQuestionWriter _writer;
+        private DbSet<EventQuestion> _questionsDbSet;
+        private DbSet<EventOption> _optionsDbSet;
+
+        private readonly Guid _eventId = Guid.NewGuid();
+
+        [SetUp]
+        public void TestInitializer()
+        {
+            _uow = Substitute.For<IUnitOfWork2>();
+            _questionsDbSet = _uow.MockDbSetForAsync(new List<EventQuestion>());
+            _optionsDbSet = _uow.MockDbSetForAsync(new List<EventOption>());
+
+            _writer = new EventQuestionWriter(_uow, new EventQuestionStructureValidator());
+        }
+
+        private static EventQuestionStructureDto Question(
+            string clientId,
+            int order,
+            string title,
+            params EventQuestionOptionStructureDto[] options)
+        {
+            return new EventQuestionStructureDto
+            {
+                Id = null,
+                ClientId = clientId,
+                Title = title,
+                Order = order,
+                SelectType = EventQuestionSelectType.Single,
+                IsRequired = true,
+                Options = options.ToList()
+            };
+        }
+
+        private static EventQuestionOptionStructureDto Option(string clientId, string name, int order)
+        {
+            return new EventQuestionOptionStructureDto
+            {
+                Id = null,
+                ClientId = clientId,
+                Name = name,
+                Order = order,
+                Rule = OptionRules.Default
+            };
+        }
+
+        [Test]
+        public async Task Should_Insert_A_Question_With_Its_Options()
+        {
+            var questions = new List<EventQuestionStructureDto>
+            {
+                Question("q1", 0, "Pick your dish", Option("o1", "Pizza", 0), Option("o2", "Pasta", 1))
+            };
+
+            await _writer.WriteAsync(_eventId, questions, "user-1");
+
+            _questionsDbSet.Received(1).Add(Arg.Is<EventQuestion>(q => q.Title == "Pick your dish" && q.EventId == _eventId));
+            _optionsDbSet.Received(2).Add(Arg.Any<EventOption>());
+            await _uow.Received(1).SaveChangesAsync("user-1");
+        }
+
+        [Test]
+        public async Task Should_Wire_A_ClientId_Condition_Through_The_Navigation_Property()
+        {
+            var trigger = Option("o1", "Pizza", 0);
+            var conditional = Question("q2", 1, "Which pizza?", Option("o3", "Margherita", 0));
+            conditional.ShowIfOptionClientId = "o1";
+
+            var questions = new List<EventQuestionStructureDto>
+            {
+                Question("q1", 0, "Pick your dish", trigger),
+                conditional
+            };
+
+            EventQuestion captured = null;
+            _questionsDbSet
+                .When(x => x.Add(Arg.Is<EventQuestion>(q => q.Title == "Which pizza?")))
+                .Do(call => captured = call.Arg<EventQuestion>());
+
+            await _writer.WriteAsync(_eventId, questions, "user-1");
+
+            Assert.That(captured, Is.Not.Null);
+            Assert.That(captured.ShowIfOption, Is.Not.Null, "the trigger row has no ID yet, so the navigation property must carry the link");
+            Assert.That(captured.ShowIfOption.Option, Is.EqualTo("Pizza"));
+        }
+
+        [Test]
+        public void Should_Reject_A_Condition_Whose_Trigger_Is_Absent_From_The_Payload()
+        {
+            var conditional = Question("q1", 0, "Which pizza?", Option("o1", "Margherita", 0));
+            conditional.ShowIfOptionClientId = "removed-in-this-request";
+
+            var questions = new List<EventQuestionStructureDto> { conditional };
+
+            Assert.ThrowsAsync<EventException>(async () => await _writer.WriteAsync(_eventId, questions, "user-1"));
+        }
+
+        [Test]
+        public void Should_Not_Write_Anything_When_Validation_Fails()
+        {
+            // A condition pointing at a question with a HIGHER order violates the strictly-lower
+            // invariant. Nothing may reach the database — the spec forbids persisting a tree whose
+            // condition was silently dropped.
+            var early = Question("q1", 0, "Early", Option("o1", "A", 0));
+            early.ShowIfOptionClientId = "o2";              // owned by q2, which sits at a higher order
+            var late = Question("q2", 1, "Late", Option("o2", "B", 0));
+
+            var questions = new List<EventQuestionStructureDto> { early, late };
+
+            Assert.ThrowsAsync<EventException>(async () => await _writer.WriteAsync(_eventId, questions, "user-1"));
+
+            _questionsDbSet.DidNotReceive().Add(Arg.Any<EventQuestion>());
+            _optionsDbSet.DidNotReceive().Add(Arg.Any<EventOption>());
+            Assert.ThrowsAsync<EventException>(async () => await _writer.WriteAsync(_eventId, questions, "user-1"));
+        }
+
+        [Test]
+        public void Should_Not_Save_When_Validation_Fails()
+        {
+            var early = Question("q1", 0, "Early", Option("o1", "A", 0));
+            early.ShowIfOptionClientId = "o2";
+            var late = Question("q2", 1, "Late", Option("o2", "B", 0));
+
+            Assert.ThrowsAsync<EventException>(
+                async () => await _writer.WriteAsync(_eventId, new List<EventQuestionStructureDto> { early, late }, "user-1"));
+
+            _uow.DidNotReceive().SaveChangesAsync(Arg.Any<string>());
+        }
+
+        [Test]
+        public async Task Should_Soft_Delete_Questions_Absent_From_The_Payload()
+        {
+            var existing = new EventQuestion
+            {
+                Id = 7,
+                EventId = _eventId,
+                Title = "Old question",
+                Order = 0,
+                IsDeleted = false,
+                Options = new List<EventOption>()
+            };
+
+            _uow = Substitute.For<IUnitOfWork2>();
+            _questionsDbSet = _uow.MockDbSetForAsync(new List<EventQuestion> { existing });
+            _optionsDbSet = _uow.MockDbSetForAsync(new List<EventOption>());
+            _writer = new EventQuestionWriter(_uow, new EventQuestionStructureValidator());
+
+            await _writer.WriteAsync(_eventId, new List<EventQuestionStructureDto>(), "user-1");
+
+            Assert.That(existing.IsDeleted, Is.True);
+            _questionsDbSet.DidNotReceive().Remove(Arg.Any<EventQuestion>());
+        }
+
+        [Test]
+        public async Task Should_Save_Exactly_Once_On_A_Successful_Write()
+        {
+            var questions = new List<EventQuestionStructureDto>
+            {
+                Question("q1", 0, "Pick your dish", Option("o1", "Pizza", 0))
+            };
+
+            await _writer.WriteAsync(_eventId, questions, "user-1");
+
+            await _uow.Received(1).SaveChangesAsync(Arg.Any<string>());
+        }
+    }
+}

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventQuestionWriterTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventServices/EventQuestionWriterTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -7,7 +7,9 @@ using NSubstitute;
 using NUnit.Framework;
 using Shrooms.Contracts.DAL;
 using Shrooms.Contracts.Enums;
+using Shrooms.Contracts.Infrastructure;
 using Shrooms.DataLayer.EntityModels.Models.Events;
+using Shrooms.Premium.Constants;
 using Shrooms.Premium.DataTransferObjects.Models.Events;
 using Shrooms.Premium.Domain.DomainExceptions.Event;
 using Shrooms.Premium.Domain.DomainServiceValidators.Events;
@@ -22,17 +24,19 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
         private IEventQuestionWriter _writer;
         private DbSet<EventQuestion> _questionsDbSet;
         private DbSet<EventOption> _optionsDbSet;
+        private ISystemClock _systemClock;
 
         private readonly Guid _eventId = Guid.NewGuid();
 
         [SetUp]
         public void TestInitializer()
         {
+            _systemClock ??= Substitute.For<ISystemClock>();
             _uow = Substitute.For<IUnitOfWork2>();
             _questionsDbSet = _uow.MockDbSetForAsync(new List<EventQuestion>());
             _optionsDbSet = _uow.MockDbSetForAsync(new List<EventOption>());
 
-            _writer = new EventQuestionWriter(_uow, new EventQuestionStructureValidator());
+            _writer = new EventQuestionWriter(_uow, new EventQuestionStructureValidator(), _systemClock);
         }
 
         private static EventQuestionStructureDto Question(
@@ -77,7 +81,7 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
 
             _questionsDbSet.Received(1).Add(Arg.Is<EventQuestion>(q => q.Title == "Pick your dish" && q.EventId == _eventId));
             _optionsDbSet.Received(2).Add(Arg.Any<EventOption>());
-            await _uow.Received(1).SaveChangesAsync("user-1");
+            await _uow.DidNotReceive().SaveChangesAsync(Arg.Any<string>());
         }
 
         [Test]
@@ -161,10 +165,11 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
                 Options = new List<EventOption>()
             };
 
+            _systemClock ??= Substitute.For<ISystemClock>();
             _uow = Substitute.For<IUnitOfWork2>();
             _questionsDbSet = _uow.MockDbSetForAsync(new List<EventQuestion> { existing });
             _optionsDbSet = _uow.MockDbSetForAsync(new List<EventOption>());
-            _writer = new EventQuestionWriter(_uow, new EventQuestionStructureValidator());
+            _writer = new EventQuestionWriter(_uow, new EventQuestionStructureValidator(), _systemClock);
 
             await _writer.WriteAsync(_eventId, new List<EventQuestionStructureDto>(), "user-1");
 
@@ -173,7 +178,7 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
         }
 
         [Test]
-        public async Task Should_Save_Exactly_Once_On_A_Successful_Write()
+        public async Task Should_Leave_Saving_To_The_Caller()
         {
             var questions = new List<EventQuestionStructureDto>
             {
@@ -182,7 +187,96 @@ namespace Shrooms.Premium.Tests.DomainService.EventServices
 
             await _writer.WriteAsync(_eventId, questions, "user-1");
 
-            await _uow.Received(1).SaveChangesAsync(Arg.Any<string>());
+            await _uow.DidNotReceive().SaveChangesAsync(Arg.Any<string>());
+            await _uow.DidNotReceive().SaveChangesAsync(Arg.Any<bool>());
+        }
+
+        [Test]
+        public void Should_Reject_A_Question_Id_That_Is_Not_This_Events()
+        {
+            var question = Question("q1", 0, "Pick your dish", Option("o1", "Pizza", 0));
+            question.Id = 999;
+
+            var ex = Assert.ThrowsAsync<EventException>(
+                () => _writer.WriteAsync(_eventId, new List<EventQuestionStructureDto> { question }, "user-1"));
+
+            Assert.That(ex.Message, Is.EqualTo(PremiumErrorCodes.EventQuestionNotFound));
+        }
+
+        [Test]
+        public async Task Should_Reject_An_Option_Id_Owned_By_Another_Question()
+        {
+            var existing = new EventQuestion
+            {
+                Id = 7,
+                EventId = _eventId,
+                Title = "Old question",
+                Order = 0,
+                Options = new List<EventOption> { new EventOption { Id = 100, EventId = _eventId, Option = "Pizza" } }
+            };
+
+            var other = new EventQuestion
+            {
+                Id = 8,
+                EventId = _eventId,
+                Title = "Other question",
+                Order = 1,
+                Options = new List<EventOption>()
+            };
+
+            _systemClock ??= Substitute.For<ISystemClock>();
+            _uow = Substitute.For<IUnitOfWork2>();
+            _questionsDbSet = _uow.MockDbSetForAsync(new List<EventQuestion> { existing, other });
+            _optionsDbSet = _uow.MockDbSetForAsync(new List<EventOption>());
+            _writer = new EventQuestionWriter(_uow, new EventQuestionStructureValidator(), _systemClock);
+
+            // Option 100 belongs to question 7; sending it under question 8 is the "dragged
+            // between questions" case that used to throw InvalidOperationException.
+            var moved = Question("q8", 1, "Other question", Option(null, "Pizza", 0));
+            moved.Id = 8;
+            moved.Options[0].Id = 100;
+
+            var ex = Assert.ThrowsAsync<EventException>(
+                () => _writer.WriteAsync(_eventId, new List<EventQuestionStructureDto> { moved }, "user-1"));
+
+            Assert.That(ex.Message, Is.EqualTo(PremiumErrorCodes.EventQuestionOptionNotFound));
+            await Task.CompletedTask;
+        }
+
+        [Test]
+        public async Task Should_Keep_A_Stored_Rule_When_The_Payload_Omits_It()
+        {
+            var storedOption = new EventOption
+            {
+                Id = 100,
+                EventId = _eventId,
+                Option = "Pizza",
+                Rule = OptionRules.IgnoreSingleJoin
+            };
+
+            var existing = new EventQuestion
+            {
+                Id = 7,
+                EventId = _eventId,
+                Title = "Pick your dish",
+                Order = 0,
+                Options = new List<EventOption> { storedOption }
+            };
+
+            _systemClock ??= Substitute.For<ISystemClock>();
+            _uow = Substitute.For<IUnitOfWork2>();
+            _questionsDbSet = _uow.MockDbSetForAsync(new List<EventQuestion> { existing });
+            _optionsDbSet = _uow.MockDbSetForAsync(new List<EventOption>());
+            _writer = new EventQuestionWriter(_uow, new EventQuestionStructureValidator(), _systemClock);
+
+            var echoed = Question("q7", 0, "Pick your dish", Option(null, "Pizza", 0));
+            echoed.Id = 7;
+            echoed.Options[0].Id = 100;
+            echoed.Options[0].Rule = null;
+
+            await _writer.WriteAsync(_eventId, new List<EventQuestionStructureDto> { echoed }, "user-1");
+
+            Assert.That(storedOption.Rule, Is.EqualTo(OptionRules.IgnoreSingleJoin));
         }
     }
 }

--- a/src/api/Shrooms.Premium.Tests/DomainService/EventsWebHookServiceTests.cs
+++ b/src/api/Shrooms.Premium.Tests/DomainService/EventsWebHookServiceTests.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using NUnit.Framework;
+using Shrooms.Contracts.Constants;
+using Shrooms.Contracts.DAL;
+using Shrooms.Contracts.DataTransferObjects.Wall;
+using Shrooms.Contracts.Enums;
+using Shrooms.Contracts.Infrastructure;
+using Shrooms.DataLayer.EntityModels.Models;
+using Shrooms.DataLayer.EntityModels.Models.Events;
+using Shrooms.Domain.Services.Wall;
+using Shrooms.Premium.Domain.Services.WebHookCallbacks.Events;
+using Shrooms.Tests.Extensions;
+
+namespace Shrooms.Premium.Tests.DomainService
+{
+    [TestFixture]
+    public class EventsWebHookServiceTests
+    {
+        private IUnitOfWork2 _uow;
+        private DbSet<Event> _eventsDbSet;
+        private DbSet<EventOption> _optionsDbSet;
+        private DbSet<EventQuestion> _questionsDbSet;
+        private IEventsWebHookService _service;
+
+        [SetUp]
+        public void TestInitializer()
+        {
+            _uow = Substitute.For<IUnitOfWork2>();
+            _eventsDbSet = _uow.MockDbSetForAsync(new List<Event>());
+            _optionsDbSet = _uow.MockDbSetForAsync(new List<EventOption>());
+            _questionsDbSet = _uow.MockDbSetForAsync(new List<EventQuestion>());
+
+            var systemClock = Substitute.For<ISystemClock>();
+            systemClock.UtcNow.Returns(DateTime.Parse("2026-09-01"));
+
+            var wallService = Substitute.For<IWallService>();
+            wallService.CreateNewWallAsync(Arg.Any<CreateWallDto>()).Returns(77);
+
+            var appSettings = Substitute.For<IApplicationSettings>();
+
+            _service = new EventsWebHookService(_uow, systemClock, wallService, appSettings);
+        }
+
+        [Test]
+        public async Task Should_Clone_The_Question_Tree_Onto_The_Next_Occurrence()
+        {
+            MockExpiredRecurringEventWithQuestions();
+
+            await _service.UpdateRecurringEventsAsync();
+
+            var clonedQuestions = _questionsDbSet.ReceivedCalls()
+                .Where(call => call.GetMethodInfo().Name == nameof(DbSet<EventQuestion>.Add))
+                .Select(call => (EventQuestion)call.GetArguments()[0])
+                .ToList();
+
+            Assert.That(clonedQuestions, Has.Count.EqualTo(2), "both questions must reach the new occurrence");
+
+            var dish = clonedQuestions.Single(q => q.Title == "Pick your dish");
+            Assert.That(dish.Options.Select(o => o.Option), Is.EquivalentTo(new[] { "Pasta", "Pizza" }));
+            Assert.That(dish.Options.Select(o => o.Order), Is.EquivalentTo(new[] { 0, 1 }), "Order must survive the clone");
+
+            var pizza = clonedQuestions.Single(q => q.Title == "Which pizza?");
+            Assert.That(pizza.ShowIfOption, Is.Not.Null, "the condition must be rewired to the cloned trigger");
+            Assert.That(pizza.ShowIfOption.Option, Is.EqualTo("Pizza"));
+            Assert.That(pizza.ShowIfOptionId, Is.Null, "the cloned trigger has no ID yet, so the link rides the navigation");
+        }
+
+        [Test]
+        public async Task Should_Not_Clone_Question_Options_As_Loose_Legacy_Options()
+        {
+            MockExpiredRecurringEventWithQuestions();
+
+            await _service.UpdateRecurringEventsAsync();
+
+            var looseOptions = _optionsDbSet.ReceivedCalls()
+                .Where(call => call.GetMethodInfo().Name == nameof(DbSet<EventOption>.Add))
+                .Select(call => (EventOption)call.GetArguments()[0])
+                .ToList();
+
+            Assert.That(looseOptions.Select(o => o.Option), Is.EquivalentTo(new[] { "Soup" }),
+                "only the legacy option may be cloned loose; answers cloned this way resurface as food choices");
+            Assert.That(looseOptions.Single().Rule, Is.EqualTo(OptionRules.IgnoreSingleJoin),
+                "Rule must survive the clone");
+        }
+
+        private void MockExpiredRecurringEventWithQuestions()
+        {
+            var eventId = Guid.NewGuid();
+
+            var soup = new EventOption { Id = 10, EventId = eventId, Option = "Soup", QuestionId = null, Order = 3, Rule = OptionRules.IgnoreSingleJoin };
+            var pasta = new EventOption { Id = 90, EventId = eventId, Option = "Pasta", QuestionId = 5, Order = 0 };
+            var pizzaOption = new EventOption { Id = 91, EventId = eventId, Option = "Pizza", QuestionId = 5, Order = 1 };
+            var margherita = new EventOption { Id = 92, EventId = eventId, Option = "Margherita", QuestionId = 6, Order = 0 };
+
+            var events = new List<Event>
+            {
+                new Event
+                {
+                    Id = eventId,
+                    OrganizationId = 2,
+                    Name = "Weekly lunch",
+                    EventRecurring = EventRecurrenceOptions.EveryWeek,
+                    EndDate = DateTime.Parse("2026-08-01"),
+                    LocalStartDate = DateTime.Parse("2026-07-31"),
+                    LocalEndDate = DateTime.Parse("2026-08-01"),
+                    LocalRegistrationDeadline = DateTime.Parse("2026-07-30"),
+                    ResponsibleUserId = "host1",
+                    ResponsibleUser = new ApplicationUser { Id = "host1", TimeZone = DataLayerConstants.DefaultTimeZone },
+                    MaxChoices = 1,
+                    EventOptions = new List<EventOption> { soup, pasta, pizzaOption, margherita },
+                    EventQuestions = new List<EventQuestion>
+                    {
+                        new EventQuestion
+                        {
+                            Id = 5, EventId = eventId, Title = "Pick your dish", Order = 0,
+                            SelectType = EventQuestionSelectType.Single, IsRequired = true,
+                            ShowIfOptionId = null, Options = new List<EventOption> { pasta, pizzaOption }
+                        },
+                        new EventQuestion
+                        {
+                            Id = 6, EventId = eventId, Title = "Which pizza?", Order = 1,
+                            SelectType = EventQuestionSelectType.Single, IsRequired = true,
+                            ShowIfOptionId = 91, Options = new List<EventOption> { margherita }
+                        }
+                    }
+                }
+            };
+
+            _eventsDbSet.SetDbSetDataForAsync(events.AsQueryable());
+        }
+    }
+}

--- a/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/EventChangeOptionsDto.cs
+++ b/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/EventChangeOptionsDto.cs
@@ -8,6 +8,17 @@ namespace Shrooms.Premium.DataTransferObjects.Models.Events
     {
         public Guid EventId { get; set; }
 
+        /// <summary>
+        /// Legacy flat options. Always replaces the participant's flat selection.
+        /// </summary>
         public IEnumerable<int> ChosenOptions { get; set; }
+
+        /// <summary>
+        /// Question-owned option ids. Null means the caller is not touching answers: the stored
+        /// ones are kept and no answer rule is enforced. An empty list clears them. Assigned by the
+        /// controller rather than AutoMapper, which maps an omitted array to an empty one and so
+        /// cannot tell "omitted" from "clear my answers".
+        /// </summary>
+        public IEnumerable<int> Answers { get; set; }
     }
 }

--- a/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/EventEditDetailsDto.cs
+++ b/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/EventEditDetailsDto.cs
@@ -51,6 +51,13 @@ namespace Shrooms.Premium.DataTransferObjects.Models.Events
 
         public IEnumerable<EventOptionDto> Options { get; set; }
 
+        /// <summary>
+        /// The sign-up question tree, so the builder can rehydrate on edit. Same shape the
+        /// options endpoint serves. Without this an edit submits an empty tree and
+        /// EventQuestionWriter.SoftDeleteAbsent wipes every existing question.
+        /// </summary>
+        public IEnumerable<EventQuestionStructureDto> Questions { get; set; } = new List<EventQuestionStructureDto>();
+
         public IEnumerable<EventReminderDetailsDto> Reminders { get; set; }
     }
 }

--- a/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/EventJoinDto.cs
+++ b/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/EventJoinDto.cs
@@ -15,6 +15,12 @@ namespace Shrooms.Premium.DataTransferObjects.Models.Events
 
         public IEnumerable<int> ChosenOptions { get; set; }
 
+        /// <summary>
+        /// Question-owned option ids. Join replaces the participant's whole selection, so null here
+        /// reads as "no answers supplied" and the answer rules are enforced against that.
+        /// </summary>
+        public IEnumerable<int> Answers { get; set; }
+
         public ICollection<string> ParticipantIds { get; set; }
     }
 }

--- a/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/EventJoinValidationDto.cs
+++ b/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/EventJoinValidationDto.cs
@@ -25,6 +25,10 @@ namespace Shrooms.Premium.DataTransferObjects.Models.Events
         public string Location { get; set; }
         public ICollection<EventOption> Options { get; set; }
         public ICollection<EventOption> SelectedOptions { get; set; }
+
+        /// <summary>Resolved question tree, for <see cref="IEventAnswerValidator"/>.</summary>
+        public List<ResolvedEventQuestionDto> Questions { get; set; } = new List<ResolvedEventQuestionDto>();
+
         public DateTime RegistrationDeadline { get; set; }
         public DateTime StartDate { get; set; }
         public List<EventParticipantAttendDto> Participants { get; set; }

--- a/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/EventJoinValidationDto.cs
+++ b/src/api/Shrooms.Premium/DataTransferObjects/Models/Events/EventJoinValidationDto.cs
@@ -23,10 +23,12 @@ namespace Shrooms.Premium.DataTransferObjects.Models.Events
         public bool AllowNotGoing { get; set; }
 
         public string Location { get; set; }
+
+        /// <summary>All event options, including options owned by questions.</summary>
         public ICollection<EventOption> Options { get; set; }
         public ICollection<EventOption> SelectedOptions { get; set; }
 
-        /// <summary>Resolved question tree, for <see cref="IEventAnswerValidator"/>.</summary>
+        /// <summary>Resolved question tree, for the answer validator.</summary>
         public List<ResolvedEventQuestionDto> Questions { get; set; } = new List<ResolvedEventQuestionDto>();
 
         public DateTime RegistrationDeadline { get; set; }

--- a/src/api/Shrooms.Premium/Domain/Services/Events/EventQuestionWriter.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/EventQuestionWriter.cs
@@ -1,28 +1,49 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Shrooms.Contracts.DAL;
+using Shrooms.Contracts.DataTransferObjects;
+using Shrooms.Contracts.Enums;
+using Shrooms.Contracts.Infrastructure;
 using Shrooms.DataLayer.EntityModels.Models.Events;
+using Shrooms.Premium.Constants;
 using Shrooms.Premium.DataTransferObjects.Models.Events;
+using Shrooms.Premium.Domain.DomainExceptions.Event;
 using Shrooms.Premium.Domain.DomainServiceValidators.Events;
 
 namespace Shrooms.Premium.Domain.Services.Events
 {
     public class EventQuestionWriter : IEventQuestionWriter
     {
-        private readonly IUnitOfWork2 _uow;
         private readonly DbSet<EventQuestion> _questionsDbSet;
         private readonly DbSet<EventOption> _optionsDbSet;
         private readonly IEventQuestionStructureValidator _structureValidator;
+        private readonly ISystemClock _systemClock;
 
-        public EventQuestionWriter(IUnitOfWork2 uow, IEventQuestionStructureValidator structureValidator)
+        public EventQuestionWriter(
+            IUnitOfWork2 uow,
+            IEventQuestionStructureValidator structureValidator,
+            ISystemClock systemClock)
         {
-            _uow = uow;
             _questionsDbSet = uow.GetDbSet<EventQuestion>();
             _optionsDbSet = uow.GetDbSet<EventOption>();
             _structureValidator = structureValidator;
+            _systemClock = systemClock;
+        }
+
+        public async Task ValidateAsync(Guid eventId, IList<EventQuestionStructureDto> questions)
+        {
+            var desired = questions ?? new List<EventQuestionStructureDto>();
+
+            _structureValidator.ValidatePayload(desired);
+
+            var existing = await LoadExistingAsync(eventId);
+
+            CheckSuppliedIdsBelongToEvent(existing, desired);
+
+            _structureValidator.ValidateResolved(BuildResolvedFromPayload(desired));
         }
 
         public async Task WriteAsync(Guid eventId, IList<EventQuestionStructureDto> questions, string userId)
@@ -31,10 +52,9 @@ namespace Shrooms.Premium.Domain.Services.Events
 
             _structureValidator.ValidatePayload(desired);
 
-            var existing = await _questionsDbSet
-                .Include(q => q.Options)
-                .Where(q => q.EventId == eventId)
-                .ToListAsync();
+            var existing = await LoadExistingAsync(eventId);
+
+            CheckSuppliedIdsBelongToEvent(existing, desired);
 
             // Validate the entire tree before touching the database. A payload that fails here must
             // leave no trace: persisting questions whose conditions were silently dropped would turn
@@ -65,8 +85,47 @@ namespace Shrooms.Premium.Domain.Services.Events
             {
                 ApplyCondition(dto, entity, optionByClientId);
             }
+        }
 
-            await _uow.SaveChangesAsync(userId);
+        private async Task<List<EventQuestion>> LoadExistingAsync(Guid eventId)
+        {
+            return await _questionsDbSet
+                .Include(q => q.Options)
+                .Where(q => q.EventId == eventId)
+                .ToListAsync();
+        }
+
+        /// <summary>
+        /// Every id the client supplies has to name a live row of this event, and an option id has
+        /// to sit under the question that claims it. Without this the lookups below throw
+        /// InvalidOperationException, which the controllers do not catch — a 500 for a stale form,
+        /// an option dragged between questions, or an id borrowed from another event.
+        /// </summary>
+        private static void CheckSuppliedIdsBelongToEvent(
+            List<EventQuestion> existing,
+            IList<EventQuestionStructureDto> desired)
+        {
+            var existingById = existing.ToDictionary(question => question.Id);
+
+            foreach (var dto in desired.Where(question => question.Id != null))
+            {
+                if (!existingById.ContainsKey(dto.Id.Value))
+                {
+                    throw new EventException(PremiumErrorCodes.EventQuestionNotFound);
+                }
+            }
+
+            foreach (var dto in desired)
+            {
+                var ownedOptionIds = dto.Id != null
+                    ? existingById[dto.Id.Value].Options?.Select(option => option.Id).ToHashSet() ?? new HashSet<int>()
+                    : new HashSet<int>();
+
+                if (dto.Options.Any(option => option.Id != null && !ownedOptionIds.Contains(option.Id.Value)))
+                {
+                    throw new EventException(PremiumErrorCodes.EventQuestionOptionNotFound);
+                }
+            }
         }
 
         /// <summary>
@@ -92,7 +151,7 @@ namespace Shrooms.Premium.Domain.Services.Events
                     var id = option.Id ?? next--;
                     syntheticOptionId[option] = id;
 
-                    if (option.ClientId != null)
+                    if (!string.IsNullOrWhiteSpace(option.ClientId))
                     {
                         syntheticOptionIdByClientId[option.ClientId] = id;
                     }
@@ -119,7 +178,7 @@ namespace Shrooms.Premium.Domain.Services.Events
                 return dto.ShowIfOptionId;
             }
 
-            if (dto.ShowIfOptionClientId == null)
+            if (string.IsNullOrWhiteSpace(dto.ShowIfOptionClientId))
             {
                 return null;
             }
@@ -143,7 +202,7 @@ namespace Shrooms.Premium.Domain.Services.Events
                 return;
             }
 
-            if (dto.ShowIfOptionClientId == null)
+            if (string.IsNullOrWhiteSpace(dto.ShowIfOptionClientId))
             {
                 entity.ShowIfOptionId = null;
                 entity.ShowIfOption = null;
@@ -200,9 +259,7 @@ namespace Shrooms.Premium.Domain.Services.Events
 
             foreach (var removed in existingOptions.Where(o => !keptIds.Contains(o.Id)))
             {
-                removed.IsDeleted = true;
-                removed.Modified = DateTime.UtcNow;
-                removed.ModifiedBy = userId;
+                SoftDelete(removed, userId);
             }
 
             foreach (var optionDto in dto.Options)
@@ -214,13 +271,13 @@ namespace Shrooms.Premium.Domain.Services.Events
                         EventId = eventId,
                         Option = optionDto.Name,
                         Order = optionDto.Order,
-                        Rule = optionDto.Rule,
+                        Rule = optionDto.Rule ?? OptionRules.Default,
                         Question = entity
                     };
 
                     _optionsDbSet.Add(option);
 
-                    if (optionDto.ClientId != null)
+                    if (!string.IsNullOrWhiteSpace(optionDto.ClientId))
                     {
                         optionByClientId[optionDto.ClientId] = option;
                     }
@@ -230,9 +287,15 @@ namespace Shrooms.Premium.Domain.Services.Events
                     var option = existingOptions.Single(o => o.Id == optionDto.Id.Value);
                     option.Option = optionDto.Name;
                     option.Order = optionDto.Order;
-                    option.Rule = optionDto.Rule;
 
-                    if (optionDto.ClientId != null)
+                    // A client that omits the rule keeps the stored one: the read shapes did not
+                    // always carry it, so treating "absent" as Default silently cleared it.
+                    if (optionDto.Rule != null)
+                    {
+                        option.Rule = optionDto.Rule.Value;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(optionDto.ClientId))
                     {
                         optionByClientId[optionDto.ClientId] = option;
                     }
@@ -240,7 +303,7 @@ namespace Shrooms.Premium.Domain.Services.Events
             }
         }
 
-        private static void SoftDeleteAbsent(
+        private void SoftDeleteAbsent(
             List<EventQuestion> existing,
             IList<EventQuestionStructureDto> desired,
             string userId)
@@ -249,16 +312,23 @@ namespace Shrooms.Premium.Domain.Services.Events
 
             foreach (var question in existing.Where(q => !keptIds.Contains(q.Id)))
             {
-                question.IsDeleted = true;
-                question.Modified = DateTime.UtcNow;
-                question.ModifiedBy = userId;
+                SoftDelete(question, userId);
 
                 foreach (var option in question.Options ?? new List<EventOption>())
                 {
-                    option.IsDeleted = true;
-                    option.Modified = DateTime.UtcNow;
-                    option.ModifiedBy = userId;
+                    SoftDelete(option, userId);
                 }
+            }
+        }
+
+        private void SoftDelete(ISoftDelete entity, string userId)
+        {
+            entity.IsDeleted = true;
+
+            if (entity is ITrackable trackable)
+            {
+                trackable.Modified = _systemClock.UtcNow;
+                trackable.ModifiedBy = userId;
             }
         }
     }

--- a/src/api/Shrooms.Premium/Domain/Services/Events/EventQuestionWriter.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/EventQuestionWriter.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Shrooms.Contracts.DAL;
+using Shrooms.DataLayer.EntityModels.Models.Events;
+using Shrooms.Premium.DataTransferObjects.Models.Events;
+using Shrooms.Premium.Domain.DomainServiceValidators.Events;
+
+namespace Shrooms.Premium.Domain.Services.Events
+{
+    public class EventQuestionWriter : IEventQuestionWriter
+    {
+        private readonly IUnitOfWork2 _uow;
+        private readonly DbSet<EventQuestion> _questionsDbSet;
+        private readonly DbSet<EventOption> _optionsDbSet;
+        private readonly IEventQuestionStructureValidator _structureValidator;
+
+        public EventQuestionWriter(IUnitOfWork2 uow, IEventQuestionStructureValidator structureValidator)
+        {
+            _uow = uow;
+            _questionsDbSet = uow.GetDbSet<EventQuestion>();
+            _optionsDbSet = uow.GetDbSet<EventOption>();
+            _structureValidator = structureValidator;
+        }
+
+        public async Task WriteAsync(Guid eventId, IList<EventQuestionStructureDto> questions, string userId)
+        {
+            var desired = questions ?? new List<EventQuestionStructureDto>();
+
+            _structureValidator.ValidatePayload(desired);
+
+            var existing = await _questionsDbSet
+                .Include(q => q.Options)
+                .Where(q => q.EventId == eventId)
+                .ToListAsync();
+
+            // Validate the entire tree before touching the database. A payload that fails here must
+            // leave no trace: persisting questions whose conditions were silently dropped would turn
+            // hidden questions into always-visible ones, which the spec explicitly forbids.
+            _structureValidator.ValidateResolved(BuildResolvedFromPayload(desired));
+
+            SoftDeleteAbsent(existing, desired, userId);
+
+            var entities = new List<(EventQuestionStructureDto Dto, EventQuestion Entity)>();
+
+            foreach (var dto in desired)
+            {
+                var entity = dto.Id == null
+                    ? InsertQuestion(eventId, dto)
+                    : UpdateQuestion(existing, dto);
+
+                entities.Add((dto, entity));
+            }
+
+            var optionByClientId = new Dictionary<string, EventOption>();
+
+            foreach (var (dto, entity) in entities)
+            {
+                WriteOptions(eventId, dto, entity, existing, optionByClientId, userId);
+            }
+
+            foreach (var (dto, entity) in entities)
+            {
+                ApplyCondition(dto, entity, optionByClientId);
+            }
+
+            await _uow.SaveChangesAsync(userId);
+        }
+
+        /// <summary>
+        /// Projects the desired payload onto <see cref="ResolvedEventQuestionDto"/> so the
+        /// structural rules can be checked before anything is inserted. Rows that do not exist yet
+        /// get a negative synthetic ID; real database identities are always positive, so the two
+        /// spaces cannot collide and the validator cannot tell them apart.
+        /// </summary>
+        private static IReadOnlyList<ResolvedEventQuestionDto> BuildResolvedFromPayload(
+            IList<EventQuestionStructureDto> desired)
+        {
+            var syntheticOptionId = new Dictionary<EventQuestionOptionStructureDto, int>();
+            var syntheticOptionIdByClientId = new Dictionary<string, int>();
+            var syntheticQuestionId = new Dictionary<EventQuestionStructureDto, int>();
+            var next = -1;
+
+            foreach (var dto in desired)
+            {
+                syntheticQuestionId[dto] = dto.Id ?? next--;
+
+                foreach (var option in dto.Options)
+                {
+                    var id = option.Id ?? next--;
+                    syntheticOptionId[option] = id;
+
+                    if (option.ClientId != null)
+                    {
+                        syntheticOptionIdByClientId[option.ClientId] = id;
+                    }
+                }
+            }
+
+            return desired.Select(dto => new ResolvedEventQuestionDto
+            {
+                QuestionId = syntheticQuestionId[dto],
+                Order = dto.Order,
+                SelectType = dto.SelectType,
+                IsRequired = dto.IsRequired,
+                ShowIfOptionId = ResolveTriggerId(dto, syntheticOptionIdByClientId),
+                OptionIds = dto.Options.Select(o => syntheticOptionId[o]).ToList()
+            }).ToList();
+        }
+
+        private static int? ResolveTriggerId(
+            EventQuestionStructureDto dto,
+            IReadOnlyDictionary<string, int> syntheticOptionIdByClientId)
+        {
+            if (dto.ShowIfOptionId != null)
+            {
+                return dto.ShowIfOptionId;
+            }
+
+            if (dto.ShowIfOptionClientId == null)
+            {
+                return null;
+            }
+
+            // A clientId naming nothing in this payload is left unresolved on purpose: the
+            // validator then fails to find an owning question and rejects the tree, which is the
+            // required behaviour for a condition pointing at a row removed in the same request.
+            return syntheticOptionIdByClientId.TryGetValue(dto.ShowIfOptionClientId, out var id)
+                ? id
+                : int.MinValue;
+        }
+
+        private static void ApplyCondition(
+            EventQuestionStructureDto dto,
+            EventQuestion entity,
+            IReadOnlyDictionary<string, EventOption> optionByClientId)
+        {
+            if (dto.ShowIfOptionId != null)
+            {
+                entity.ShowIfOptionId = dto.ShowIfOptionId;
+                return;
+            }
+
+            if (dto.ShowIfOptionClientId == null)
+            {
+                entity.ShowIfOptionId = null;
+                entity.ShowIfOption = null;
+                return;
+            }
+
+            // The trigger row is being inserted in this same request and has no ID yet, so the link
+            // rides on the navigation property and EF assigns the foreign key during SaveChanges.
+            entity.ShowIfOption = optionByClientId[dto.ShowIfOptionClientId];
+        }
+
+        private EventQuestion InsertQuestion(Guid eventId, EventQuestionStructureDto dto)
+        {
+            var entity = new EventQuestion
+            {
+                EventId = eventId,
+                Title = dto.Title,
+                Order = dto.Order,
+                SelectType = dto.SelectType,
+                IsRequired = dto.IsRequired,
+                Options = new List<EventOption>()
+            };
+
+            _questionsDbSet.Add(entity);
+            return entity;
+        }
+
+        private static EventQuestion UpdateQuestion(List<EventQuestion> existing, EventQuestionStructureDto dto)
+        {
+            var entity = existing.Single(q => q.Id == dto.Id);
+
+            entity.Title = dto.Title;
+            entity.Order = dto.Order;
+            entity.SelectType = dto.SelectType;
+            entity.IsRequired = dto.IsRequired;
+
+            return entity;
+        }
+
+        private void WriteOptions(
+            Guid eventId,
+            EventQuestionStructureDto dto,
+            EventQuestion entity,
+            List<EventQuestion> existing,
+            Dictionary<string, EventOption> optionByClientId,
+            string userId)
+        {
+            var existingOptions = existing
+                .Where(q => q.Id == dto.Id)
+                .SelectMany(q => q.Options ?? new List<EventOption>())
+                .ToList();
+
+            var keptIds = dto.Options.Where(o => o.Id != null).Select(o => o.Id.Value).ToHashSet();
+
+            foreach (var removed in existingOptions.Where(o => !keptIds.Contains(o.Id)))
+            {
+                removed.IsDeleted = true;
+                removed.Modified = DateTime.UtcNow;
+                removed.ModifiedBy = userId;
+            }
+
+            foreach (var optionDto in dto.Options)
+            {
+                if (optionDto.Id == null)
+                {
+                    var option = new EventOption
+                    {
+                        EventId = eventId,
+                        Option = optionDto.Name,
+                        Order = optionDto.Order,
+                        Rule = optionDto.Rule,
+                        Question = entity
+                    };
+
+                    _optionsDbSet.Add(option);
+
+                    if (optionDto.ClientId != null)
+                    {
+                        optionByClientId[optionDto.ClientId] = option;
+                    }
+                }
+                else
+                {
+                    var option = existingOptions.Single(o => o.Id == optionDto.Id.Value);
+                    option.Option = optionDto.Name;
+                    option.Order = optionDto.Order;
+                    option.Rule = optionDto.Rule;
+
+                    if (optionDto.ClientId != null)
+                    {
+                        optionByClientId[optionDto.ClientId] = option;
+                    }
+                }
+            }
+        }
+
+        private static void SoftDeleteAbsent(
+            List<EventQuestion> existing,
+            IList<EventQuestionStructureDto> desired,
+            string userId)
+        {
+            var keptIds = desired.Where(q => q.Id != null).Select(q => q.Id.Value).ToHashSet();
+
+            foreach (var question in existing.Where(q => !keptIds.Contains(q.Id)))
+            {
+                question.IsDeleted = true;
+                question.Modified = DateTime.UtcNow;
+                question.ModifiedBy = userId;
+
+                foreach (var option in question.Options ?? new List<EventOption>())
+                {
+                    option.IsDeleted = true;
+                    option.Modified = DateTime.UtcNow;
+                    option.ModifiedBy = userId;
+                }
+            }
+        }
+    }
+}

--- a/src/api/Shrooms.Premium/Domain/Services/Events/EventQuestionWriter.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/EventQuestionWriter.cs
@@ -4,9 +4,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Shrooms.Contracts.DAL;
-using Shrooms.Contracts.DataTransferObjects;
 using Shrooms.Contracts.Enums;
 using Shrooms.Contracts.Infrastructure;
+using Shrooms.DataLayer.EntityModels.Models;
 using Shrooms.DataLayer.EntityModels.Models.Events;
 using Shrooms.Premium.Constants;
 using Shrooms.Premium.DataTransferObjects.Models.Events;
@@ -33,13 +33,17 @@ namespace Shrooms.Premium.Domain.Services.Events
             _systemClock = systemClock;
         }
 
-        public async Task ValidateAsync(Guid eventId, IList<EventQuestionStructureDto> questions)
+        public async Task ValidateAsync(Guid? eventId, IList<EventQuestionStructureDto> questions)
         {
             var desired = questions ?? new List<EventQuestionStructureDto>();
 
             _structureValidator.ValidatePayload(desired);
 
-            var existing = await LoadExistingAsync(eventId);
+            // No event yet, so nothing can be referenced by id. Skipping the load also keeps
+            // create from querying for rows that cannot exist.
+            var existing = eventId == null
+                ? new List<EventQuestion>()
+                : await LoadExistingAsync(eventId.Value);
 
             CheckSuppliedIdsBelongToEvent(existing, desired);
 
@@ -321,15 +325,11 @@ namespace Shrooms.Premium.Domain.Services.Events
             }
         }
 
-        private void SoftDelete(ISoftDelete entity, string userId)
+        private void SoftDelete(SoftDeletableModel entity, string userId)
         {
             entity.IsDeleted = true;
-
-            if (entity is ITrackable trackable)
-            {
-                trackable.Modified = _systemClock.UtcNow;
-                trackable.ModifiedBy = userId;
-            }
+            entity.Modified = _systemClock.UtcNow;
+            entity.ModifiedBy = userId;
         }
     }
 }

--- a/src/api/Shrooms.Premium/Domain/Services/Events/EventQuestionWriter.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/EventQuestionWriter.cs
@@ -72,8 +72,8 @@ namespace Shrooms.Premium.Domain.Services.Events
             foreach (var dto in desired)
             {
                 var entity = dto.Id == null
-                    ? InsertQuestion(eventId, dto)
-                    : UpdateQuestion(existing, dto);
+                    ? InsertQuestion(eventId, dto, userId)
+                    : UpdateQuestion(existing, dto, userId);
 
                 entities.Add((dto, entity));
             }
@@ -218,7 +218,7 @@ namespace Shrooms.Premium.Domain.Services.Events
             entity.ShowIfOption = optionByClientId[dto.ShowIfOptionClientId];
         }
 
-        private EventQuestion InsertQuestion(Guid eventId, EventQuestionStructureDto dto)
+        private EventQuestion InsertQuestion(Guid eventId, EventQuestionStructureDto dto, string userId)
         {
             var entity = new EventQuestion
             {
@@ -230,11 +230,13 @@ namespace Shrooms.Premium.Domain.Services.Events
                 Options = new List<EventOption>()
             };
 
+            StampCreated(entity, userId);
+
             _questionsDbSet.Add(entity);
             return entity;
         }
 
-        private static EventQuestion UpdateQuestion(List<EventQuestion> existing, EventQuestionStructureDto dto)
+        private EventQuestion UpdateQuestion(List<EventQuestion> existing, EventQuestionStructureDto dto, string userId)
         {
             var entity = existing.Single(q => q.Id == dto.Id);
 
@@ -242,6 +244,8 @@ namespace Shrooms.Premium.Domain.Services.Events
             entity.Order = dto.Order;
             entity.SelectType = dto.SelectType;
             entity.IsRequired = dto.IsRequired;
+
+            StampModified(entity, userId);
 
             return entity;
         }
@@ -279,6 +283,8 @@ namespace Shrooms.Premium.Domain.Services.Events
                         Question = entity
                     };
 
+                    StampCreated(option, userId);
+
                     _optionsDbSet.Add(option);
 
                     if (!string.IsNullOrWhiteSpace(optionDto.ClientId))
@@ -298,6 +304,8 @@ namespace Shrooms.Premium.Domain.Services.Events
                     {
                         option.Rule = optionDto.Rule.Value;
                     }
+
+                    StampModified(option, userId);
 
                     if (!string.IsNullOrWhiteSpace(optionDto.ClientId))
                     {
@@ -328,6 +336,22 @@ namespace Shrooms.Premium.Domain.Services.Events
         private void SoftDelete(SoftDeletableModel entity, string userId)
         {
             entity.IsDeleted = true;
+            StampModified(entity, userId);
+        }
+
+        // Both callers of this writer finish with SaveChangesAsync(false), which skips
+        // ShroomsDbContext.UpdateEntityMetadata, so nothing else fills these in. Without the stamp
+        // an inserted row lands with Created = 0001-01-01 and CreatedBy = NULL. The legacy option
+        // path in EventService.UpdateEventOptions sets them by hand for the same reason.
+        private void StampCreated(BaseModel entity, string userId)
+        {
+            entity.Created = _systemClock.UtcNow;
+            entity.CreatedBy = userId;
+            StampModified(entity, userId);
+        }
+
+        private void StampModified(BaseModel entity, string userId)
+        {
             entity.Modified = _systemClock.UtcNow;
             entity.ModifiedBy = userId;
         }

--- a/src/api/Shrooms.Premium/Domain/Services/Events/EventService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/EventService.cs
@@ -101,6 +101,10 @@ namespace Shrooms.Premium.Domain.Services.Events
             await _eventUtilitiesService.DeleteEventOptionsAsync(id, userOrg.UserId);
             await RemoveEventRemindersAsync(@event.Reminders, userOrg.UserId);
 
+            // DeleteEventOptionsAsync takes the question-owned options with it, so leaving the
+            // questions behind would strand live rows with every option deleted.
+            await _eventQuestionWriter.WriteAsync(id, null, userOrg.UserId);
+
             _eventsDbSet.Remove(@event);
 
             await _uow.SaveChangesAsync(false);
@@ -178,6 +182,10 @@ namespace Shrooms.Premium.Domain.Services.Events
             _eventValidationService.CheckIfCreatingEventHasInsufficientOptions(newEventDto.MaxOptions, newEventDto.NewOptions.Count());
             _eventValidationService.CheckIfCreatingEventHasNoChoices(newEventDto.MaxOptions, newEventDto.NewOptions.Count());
 
+            // Before the event row is committed: an invalid question tree returned 400 while the
+            // event was already persisted, leaving an orphan the caller could not find or retry.
+            await _eventQuestionWriter.ValidateAsync(Guid.Empty, newEventDto.Questions);
+
             var newEvent = await MapNewEventAsync(newEventDto);
 
             _eventsDbSet.Add(newEvent);
@@ -186,6 +194,7 @@ namespace Shrooms.Premium.Domain.Services.Events
             await _uow.SaveChangesAsync(newEventDto.UserId);
 
             await _eventQuestionWriter.WriteAsync(newEvent.Id, newEventDto.Questions, newEventDto.UserId);
+            await _uow.SaveChangesAsync(newEventDto.UserId);
 
             newEventDto.Id = newEvent.Id.ToString();
 
@@ -231,6 +240,12 @@ namespace Shrooms.Premium.Domain.Services.Events
             _eventValidationService.CheckIfAttendOptionsAllowedToUpdate(eventDto, eventToUpdate);
 
             await ValidateEvent(eventDto);
+
+            // With the other rules, before anything mutates: ResetEventAttendessAsync commits the
+            // expulsions and sends their emails, so a question tree rejected afterwards would
+            // return 400 with the attendee list already wiped.
+            await _eventQuestionWriter.ValidateAsync(eventToUpdate.Id, eventDto.Questions);
+
             await ResetEventAttendessAsync(eventToUpdate, eventDto);
             await UpdateWallAsync(eventToUpdate, eventDto);
             await UpdateEventInfoAsync(eventDto, eventToUpdate);

--- a/src/api/Shrooms.Premium/Domain/Services/Events/EventService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/EventService.cs
@@ -344,12 +344,18 @@ namespace Shrooms.Premium.Domain.Services.Events
                     Type = reminder.Type,
                     RemindedCount = reminder.RemindedCount
                 }),
-                Options = e.EventOptions.Select(o => new EventOptionDto
-                {
-                    Id = o.Id,
-                    Option = o.Option,
-                    Rule = o.Rule
-                }),
+                // Legacy flat options only. Question-owned options are returned under Questions;
+                // leaving them here also leaks them into the edit payload's editedOptions, which
+                // inflates totalOptionsProvided and trips CheckIfCreatingEventHasNoChoices on any
+                // question-bearing event. Mirrors EventListingService.MapOptionsToDto().
+                Options = e.EventOptions
+                    .Where(o => o.QuestionId == null)
+                    .Select(o => new EventOptionDto
+                    {
+                        Id = o.Id,
+                        Option = o.Option,
+                        Rule = o.Rule
+                    }),
                 Questions = e.EventQuestions
                     .OrderBy(q => q.Order)
                     .Select(q => new EventQuestionStructureDto
@@ -428,13 +434,20 @@ namespace Shrooms.Premium.Domain.Services.Events
 
         private void UpdateEventOptions(EditEventDto editedEvent, Event @event)
         {
+            // @event.EventOptions also holds question-owned options (QuestionId != null), which
+            // belong solely to EventQuestionWriter. EditedOptions only ever carries legacy
+            // options (see MapToEventEditDetailsDto), so scoping both the edit loop and the
+            // removal sweep to QuestionId == null keeps this method from treating every absent
+            // question option as "removed" and hard-deleting it.
+            var legacyOptions = @event.EventOptions.Where(o => o.QuestionId == null).ToList();
+
             foreach (var editedOption in editedEvent.EditedOptions)
             {
-                var option = @event.EventOptions.Single(o => o.Id == editedOption.Id);
+                var option = legacyOptions.Single(o => o.Id == editedOption.Id);
                 option.Option = editedOption.Option;
             }
 
-            var removedOptions = @event.EventOptions.Where(o => !editedEvent.EditedOptions.Select(x => x.Id).Contains(o.Id)).ToList();
+            var removedOptions = legacyOptions.Where(o => !editedEvent.EditedOptions.Select(x => x.Id).Contains(o.Id)).ToList();
 
             foreach (var option in removedOptions)
             {

--- a/src/api/Shrooms.Premium/Domain/Services/Events/EventService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/EventService.cs
@@ -184,7 +184,7 @@ namespace Shrooms.Premium.Domain.Services.Events
 
             // Before the event row is committed: an invalid question tree returned 400 while the
             // event was already persisted, leaving an orphan the caller could not find or retry.
-            await _eventQuestionWriter.ValidateAsync(Guid.Empty, newEventDto.Questions);
+            await _eventQuestionWriter.ValidateAsync(null, newEventDto.Questions);
 
             var newEvent = await MapNewEventAsync(newEventDto);
 

--- a/src/api/Shrooms.Premium/Domain/Services/Events/EventService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/EventService.cs
@@ -39,6 +39,7 @@ namespace Shrooms.Premium.Domain.Services.Events
         private readonly IMarkdownConverter _markdownConverter;
         private readonly IOfficeMapService _officeMapService;
         private readonly ISystemClock _systemClock;
+        private readonly IEventQuestionWriter _eventQuestionWriter;
 
         private readonly DbSet<Event> _eventsDbSet;
         private readonly DbSet<EventType> _eventTypesDbSet;
@@ -55,7 +56,8 @@ namespace Shrooms.Premium.Domain.Services.Events
             IWallService wallService,
             IMarkdownConverter markdownConverter,
             IOfficeMapService officeMapService,
-            ISystemClock systemClock)
+            ISystemClock systemClock,
+            IEventQuestionWriter eventQuestionWriter)
         {
             _uow = uow;
             _eventsDbSet = uow.GetDbSet<Event>();
@@ -73,6 +75,7 @@ namespace Shrooms.Premium.Domain.Services.Events
             _markdownConverter = markdownConverter;
             _officeMapService = officeMapService;
             _systemClock = systemClock;
+            _eventQuestionWriter = eventQuestionWriter;
         }
 
         public async Task DeleteAsync(Guid id, UserAndOrganizationDto userOrg)
@@ -181,6 +184,8 @@ namespace Shrooms.Premium.Domain.Services.Events
             MapNewOptions(newEventDto, newEvent);
             await _uow.SaveChangesAsync(newEventDto.UserId);
 
+            await _eventQuestionWriter.WriteAsync(newEvent.Id, newEventDto.Questions, newEventDto.UserId);
+
             newEventDto.Id = newEvent.Id.ToString();
 
             return newEventDto;
@@ -229,6 +234,8 @@ namespace Shrooms.Premium.Domain.Services.Events
             await UpdateWallAsync(eventToUpdate, eventDto);
             await UpdateEventInfoAsync(eventDto, eventToUpdate);
             UpdateEventOptions(eventDto, eventToUpdate);
+
+            await _eventQuestionWriter.WriteAsync(eventToUpdate.Id, eventDto.Questions, eventDto.UserId);
 
             await _uow.SaveChangesAsync(false);
 

--- a/src/api/Shrooms.Premium/Domain/Services/Events/EventService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/EventService.cs
@@ -112,6 +112,7 @@ namespace Shrooms.Premium.Domain.Services.Events
             var @event = await _eventsDbSet
                 .Include(e => e.ResponsibleUser)
                 .Include(e => e.Reminders)
+                .Include(e => e.EventQuestions).ThenInclude(q => q.Options)
                 .Where(e => e.Id == id && e.OrganizationId == userOrg.OrganizationId)
                 .Select(MapToEventEditDetailsDto())
                 .SingleOrDefaultAsync();
@@ -348,7 +349,29 @@ namespace Shrooms.Premium.Domain.Services.Events
                     Id = o.Id,
                     Option = o.Option,
                     Rule = o.Rule
-                })
+                }),
+                Questions = e.EventQuestions
+                    .OrderBy(q => q.Order)
+                    .Select(q => new EventQuestionStructureDto
+                    {
+                        Id = q.Id,
+                        Title = q.Title,
+                        Order = q.Order,
+                        SelectType = q.SelectType,
+                        IsRequired = q.IsRequired,
+                        ShowIfOptionId = q.ShowIfOptionId,
+                        Options = q.Options
+                            .OrderBy(o => o.Order)
+                            .Select(o => new EventQuestionOptionStructureDto
+                            {
+                                Id = o.Id,
+                                Name = o.Option,
+                                Order = o.Order,
+                                Rule = o.Rule
+                            })
+                            .ToList()
+                    })
+                    .ToList()
             };
         }
 

--- a/src/api/Shrooms.Premium/Domain/Services/Events/IEventQuestionWriter.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/IEventQuestionWriter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Shrooms.Premium.DataTransferObjects.Models.Events;
@@ -8,9 +8,15 @@ namespace Shrooms.Premium.Domain.Services.Events
     public interface IEventQuestionWriter
     {
         /// <summary>
-        /// Applies the full desired state of an event's question tree. Rows present in the
-        /// database but absent from <paramref name="questions"/> are soft-deleted. The tree is
-        /// validated in full before anything is written, so a rejected payload leaves no trace.
+        /// Validates an event's desired question tree without touching the database, so a caller
+        /// can reject a bad payload before it commits anything of its own.
+        /// </summary>
+        Task ValidateAsync(Guid eventId, IList<EventQuestionStructureDto> questions);
+
+        /// <summary>
+        /// Stages the full desired state of an event's question tree. Rows present in the
+        /// database but absent from <paramref name="questions"/> are soft-deleted. Changes are
+        /// left for the caller to save, so the whole update commits or none of it does.
         /// </summary>
         Task WriteAsync(Guid eventId, IList<EventQuestionStructureDto> questions, string userId);
     }

--- a/src/api/Shrooms.Premium/Domain/Services/Events/IEventQuestionWriter.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/IEventQuestionWriter.cs
@@ -8,10 +8,12 @@ namespace Shrooms.Premium.Domain.Services.Events
     public interface IEventQuestionWriter
     {
         /// <summary>
-        /// Validates an event's desired question tree without touching the database, so a caller
-        /// can reject a bad payload before it commits anything of its own.
+        /// Validates an event's desired question tree without writing anything, so a caller can
+        /// reject a bad payload before it commits work of its own. Pass a null
+        /// <paramref name="eventId"/> when the event does not exist yet, which also asserts that
+        /// the payload references nothing by id.
         /// </summary>
-        Task ValidateAsync(Guid eventId, IList<EventQuestionStructureDto> questions);
+        Task ValidateAsync(Guid? eventId, IList<EventQuestionStructureDto> questions);
 
         /// <summary>
         /// Stages the full desired state of an event's question tree. Rows present in the

--- a/src/api/Shrooms.Premium/Domain/Services/Events/IEventQuestionWriter.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/IEventQuestionWriter.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Shrooms.Premium.DataTransferObjects.Models.Events;
+
+namespace Shrooms.Premium.Domain.Services.Events
+{
+    public interface IEventQuestionWriter
+    {
+        /// <summary>
+        /// Applies the full desired state of an event's question tree. Rows present in the
+        /// database but absent from <paramref name="questions"/> are soft-deleted. The tree is
+        /// validated in full before anything is written, so a rejected payload leaves no trace.
+        /// </summary>
+        Task WriteAsync(Guid eventId, IList<EventQuestionStructureDto> questions, string userId);
+    }
+}

--- a/src/api/Shrooms.Premium/Domain/Services/Events/List/EventListingService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/List/EventListingService.cs
@@ -66,6 +66,14 @@ namespace Shrooms.Premium.Domain.Services.Events.List
                 .SingleOrDefaultAsync();
 
             _eventValidationService.CheckIfEventExists(eventOptionsDto);
+
+            // A second small query rather than reshaping MapOptionsToDto: that expression is
+            // static over Event and has no way to see who is asking.
+            eventOptionsDto.MyChosenOptions = await _eventParticipantsDbSet
+                .Where(p => p.EventId == eventId && p.ApplicationUserId == userOrg.UserId)
+                .SelectMany(p => p.EventOptions.Select(o => o.Id))
+                .ToListAsync();
+
             return eventOptionsDto;
         }
 

--- a/src/api/Shrooms.Premium/Domain/Services/Events/List/EventListingService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/List/EventListingService.cs
@@ -165,6 +165,7 @@ namespace Shrooms.Premium.Domain.Services.Events.List
                         SelectedOption = e.EventParticipants
                             .Where(p => p.ApplicationUserId == userOrg.UserId)
                             .SelectMany(p => p.EventOptions)
+                            .Where(o => o.QuestionId == null)
                             .OrderBy(o => o.Id)
                             .Select(o => o.Option)
                             .FirstOrDefault()

--- a/src/api/Shrooms.Premium/Domain/Services/Events/List/EventListingService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/List/EventListingService.cs
@@ -60,6 +60,7 @@ namespace Shrooms.Premium.Domain.Services.Events.List
         {
             var eventOptionsDto = await _eventsDbSet
                 .Include(e => e.EventOptions)
+                .Include(e => e.EventQuestions).ThenInclude(q => q.Options)
                 .Where(e => e.Id == eventId && e.OrganizationId == userOrg.OrganizationId)
                 .Select(MapOptionsToDto())
                 .SingleOrDefaultAsync();
@@ -413,13 +414,42 @@ namespace Shrooms.Premium.Domain.Services.Events.List
             return e => new EventOptionsDto
             {
                 MaxOptions = e.MaxChoices,
-                Options = e.EventOptions.Select(o => new EventOptionDto
+
+                // Legacy flat options only. Question options are returned under Questions below;
+                // without this filter they appear in both places and the wizard's choices show up
+                // as though they were top-level food options.
+                Options = e.EventOptions
+                    .Where(o => o.QuestionId == null)
+                    .Select(o => new EventOptionDto
                     {
                         Id = o.Id,
                         Option = o.Option,
                         Rule = o.Rule
                     })
                     .OrderByDescending(o => o.Rule == OptionRules.Default)
+                    .ToList(),
+
+                Questions = e.EventQuestions
+                    .OrderBy(q => q.Order)
+                    .Select(q => new EventQuestionStructureDto
+                    {
+                        Id = q.Id,
+                        Title = q.Title,
+                        Order = q.Order,
+                        SelectType = q.SelectType,
+                        IsRequired = q.IsRequired,
+                        ShowIfOptionId = q.ShowIfOptionId,
+                        Options = q.Options
+                            .OrderBy(o => o.Order)
+                            .Select(o => new EventQuestionOptionStructureDto
+                            {
+                                Id = o.Id,
+                                Name = o.Option,
+                                Order = o.Order,
+                                Rule = o.Rule
+                            })
+                            .ToList()
+                    })
                     .ToList()
             };
         }

--- a/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
@@ -315,20 +315,27 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
                 .Where(option => changeOptionsDto.ChosenOptions.Contains(option.Id))
                 .ToList();
 
+            var chosenOptions = changeOptionsDto.ChosenOptions.ToList();
             var legacyOptionIds = LegacyOptionIds(eventEntity.Options);
-            var legacyChosenCount = changeOptionsDto.ChosenOptions.Count(legacyOptionIds.Contains);
+            var legacyChosenCount = chosenOptions.Count(legacyOptionIds.Contains);
 
             _eventValidationService.CheckIfRegistrationDeadlineIsExpired(eventEntity.RegistrationDeadline);
-            _eventValidationService.CheckIfProvidedOptionsAreValid(changeOptionsDto.ChosenOptions, eventEntity.SelectedOptions);
+            _eventValidationService.CheckIfProvidedOptionsAreValid(chosenOptions, eventEntity.SelectedOptions);
             _eventValidationService.CheckIfJoiningNotEnoughChoicesProvided(eventEntity.MaxChoices, legacyChosenCount);
             _eventValidationService.CheckIfJoiningTooManyChoicesProvided(eventEntity.MaxChoices, legacyChosenCount);
-            _eventValidationService.CheckIfSingleChoiceSelectedWithRule(eventEntity.SelectedOptions, OptionRules.IgnoreSingleJoin);
+
+            // Only legacy options participate in the single-choice-with-rule check; question
+            // answers are not counted here for the same reason they are excluded from MaxChoices.
+            _eventValidationService.CheckIfSingleChoiceSelectedWithRule(
+                eventEntity.SelectedOptions.Where(option => option.QuestionId == null).ToList(),
+                OptionRules.IgnoreSingleJoin);
+
             _eventValidationService.CheckIfUserParticipatesInEvent(changeOptionsDto.UserId, eventEntity.Participants);
 
             _eventAnswerValidator.Validate(
                 eventEntity.Questions,
-                changeOptionsDto.ChosenOptions.ToList(),
-                LegacyOptionIds(eventEntity.Options));
+                chosenOptions,
+                legacyOptionIds);
 
             await ValidateSingleJoinForSameTypeEventsAsync(eventEntity, changeOptionsDto.OrganizationId, changeOptionsDto.UserId);
 
@@ -352,7 +359,13 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
             _eventValidationService.CheckIfProvidedOptionsAreValid(chosenOptions, eventDto.SelectedOptions);
             _eventValidationService.CheckIfJoiningNotEnoughChoicesProvided(eventDto.MaxChoices, legacyChosenCount);
             _eventValidationService.CheckIfJoiningTooManyChoicesProvided(eventDto.MaxChoices, legacyChosenCount);
-            _eventValidationService.CheckIfSingleChoiceSelectedWithRule(eventDto.SelectedOptions, OptionRules.IgnoreSingleJoin);
+
+            // Only legacy options participate in the single-choice-with-rule check; question
+            // answers are not counted here for the same reason they are excluded from MaxChoices.
+            _eventValidationService.CheckIfSingleChoiceSelectedWithRule(
+                eventDto.SelectedOptions.Where(option => option.QuestionId == null).ToList(),
+                OptionRules.IgnoreSingleJoin);
+
             _eventValidationService.CheckIfJoinAttendStatusIsValid(joinDto.AttendStatus, eventDto);
             _eventValidationService.CheckIfCanJoinEvent(joinDto, eventDto);
 

--- a/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
@@ -320,6 +320,12 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
             var legacyChosenCount = chosenOptions.Count(legacyOptionIds.Contains);
 
             _eventValidationService.CheckIfRegistrationDeadlineIsExpired(eventEntity.RegistrationDeadline);
+
+            // Ahead of CheckIfProvidedOptionsAreValid, which also rejects an unknown option but
+            // with a bare code. Running it first means the client gets the structured payload
+            // naming the offending option instead.
+            _eventAnswerValidator.Validate(eventEntity.Questions, chosenOptions, legacyOptionIds);
+
             _eventValidationService.CheckIfProvidedOptionsAreValid(chosenOptions, eventEntity.SelectedOptions);
             _eventValidationService.CheckIfJoiningNotEnoughChoicesProvided(eventEntity.MaxChoices, legacyChosenCount);
             _eventValidationService.CheckIfJoiningTooManyChoicesProvided(eventEntity.MaxChoices, legacyChosenCount);
@@ -331,11 +337,6 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
                 OptionRules.IgnoreSingleJoin);
 
             _eventValidationService.CheckIfUserParticipatesInEvent(changeOptionsDto.UserId, eventEntity.Participants);
-
-            _eventAnswerValidator.Validate(
-                eventEntity.Questions,
-                chosenOptions,
-                legacyOptionIds);
 
             await ValidateSingleJoinForSameTypeEventsAsync(eventEntity, changeOptionsDto.OrganizationId, changeOptionsDto.UserId);
 
@@ -356,6 +357,11 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
             var legacyChosenCount = chosenOptions.Count(legacyOptionIds.Contains);
 
             _eventValidationService.CheckIfRegistrationDeadlineIsExpired(eventDto.RegistrationDeadline);
+
+            // Ahead of CheckIfProvidedOptionsAreValid, so an unknown option reaches the client as
+            // the structured payload naming it rather than a bare code.
+            _eventAnswerValidator.Validate(eventDto.Questions, chosenOptions, legacyOptionIds);
+
             _eventValidationService.CheckIfProvidedOptionsAreValid(chosenOptions, eventDto.SelectedOptions);
             _eventValidationService.CheckIfJoiningNotEnoughChoicesProvided(eventDto.MaxChoices, legacyChosenCount);
             _eventValidationService.CheckIfJoiningTooManyChoicesProvided(eventDto.MaxChoices, legacyChosenCount);
@@ -368,8 +374,6 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
 
             _eventValidationService.CheckIfJoinAttendStatusIsValid(joinDto.AttendStatus, eventDto);
             _eventValidationService.CheckIfCanJoinEvent(joinDto, eventDto);
-
-            _eventAnswerValidator.Validate(eventDto.Questions, chosenOptions, legacyOptionIds);
         }
 
         private void NotifyManagers(IEnumerable<UserEventAttendStatusChangeEmailDto> userEventAttendStatusChangeEmailDtos)
@@ -648,8 +652,15 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
 
         private async Task ValidateSingleJoinForSameTypeEventsAsync(EventJoinValidationDto validationDto, int orgId, string userId)
         {
-            if (validationDto.SelectedOptions.All(x => x.Rule == OptionRules.IgnoreSingleJoin) &&
-                validationDto.SelectedOptions.Count != 0 ||
+            // Legacy options only, as everywhere else this rule is applied. Question answers carry
+            // Rule = Default, so counting them here would make All(...) false and silently revoke
+            // the multi-join exemption for anyone who answered a question.
+            var legacySelectedOptions = validationDto.SelectedOptions
+                .Where(option => option.QuestionId == null)
+                .ToList();
+
+            if (legacySelectedOptions.All(x => x.Rule == OptionRules.IgnoreSingleJoin) &&
+                legacySelectedOptions.Count != 0 ||
                 !validationDto.IsSingleJoin)
             {
                 return;
@@ -677,8 +688,8 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
 
             var anyEventsAlreadyJoined = await query.AnyAsync(x => !x.EventParticipants.Any(y =>
                 y.ApplicationUserId == userId &&
-                y.EventOptions.All(z => z.Rule == OptionRules.IgnoreSingleJoin) &&
-                y.EventOptions.Count > 0));
+                y.EventOptions.Where(z => z.QuestionId == null).All(z => z.Rule == OptionRules.IgnoreSingleJoin) &&
+                y.EventOptions.Count(z => z.QuestionId == null) > 0));
 
             _eventValidationService.CheckIfUserExistsInOtherSingleJoinEvent(anyEventsAlreadyJoined);
         }

--- a/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
@@ -302,6 +302,7 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
         {
             var eventEntity = await _eventsDbSet
                 .Include(x => x.EventOptions)
+                .Include(x => x.EventQuestions).ThenInclude(q => q.Options)
                 .Include(x => x.EventParticipants)
                 .Where(x => x.Id == changeOptionsDto.EventId && x.OrganizationId == changeOptionsDto.OrganizationId)
                 .Select(MapEventToJoinValidationDto)
@@ -323,6 +324,11 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
             _eventValidationService.CheckIfJoiningTooManyChoicesProvided(eventEntity.MaxChoices, legacyChosenCount);
             _eventValidationService.CheckIfSingleChoiceSelectedWithRule(eventEntity.SelectedOptions, OptionRules.IgnoreSingleJoin);
             _eventValidationService.CheckIfUserParticipatesInEvent(changeOptionsDto.UserId, eventEntity.Participants);
+
+            _eventAnswerValidator.Validate(
+                eventEntity.Questions,
+                changeOptionsDto.ChosenOptions.ToList(),
+                LegacyOptionIds(eventEntity.Options));
 
             await ValidateSingleJoinForSameTypeEventsAsync(eventEntity, changeOptionsDto.OrganizationId, changeOptionsDto.UserId);
 

--- a/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
@@ -334,7 +334,7 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
             _eventValidationService.CheckIfUserParticipatesInEvent(changeOptionsDto.UserId, eventEntity.Participants);
 
             // After the capacity and membership rules, so those keep reporting their own codes.
-            _eventAnswerValidator.Validate(eventEntity.Questions, chosenOptions, legacyOptionIds);
+            _eventAnswerValidator.Validate(eventEntity.Questions, chosenOptions);
 
             await ValidateSingleJoinForSameTypeEventsAsync(eventEntity, changeOptionsDto.OrganizationId, changeOptionsDto.UserId);
 
@@ -373,7 +373,7 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
             // error. CheckIfProvidedOptionsAreValid above already rejects an unknown option with
             // code 215, which the web client has a message for, so UnknownOption here is a
             // backstop for callers that skip that check.
-            _eventAnswerValidator.Validate(eventDto.Questions, chosenOptions, legacyOptionIds);
+            _eventAnswerValidator.Validate(eventDto.Questions, chosenOptions);
         }
 
         private void NotifyManagers(IEnumerable<UserEventAttendStatusChangeEmailDto> userEventAttendStatusChangeEmailDtos)

--- a/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
@@ -321,11 +321,6 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
 
             _eventValidationService.CheckIfRegistrationDeadlineIsExpired(eventEntity.RegistrationDeadline);
 
-            // Ahead of CheckIfProvidedOptionsAreValid, which also rejects an unknown option but
-            // with a bare code. Running it first means the client gets the structured payload
-            // naming the offending option instead.
-            _eventAnswerValidator.Validate(eventEntity.Questions, chosenOptions, legacyOptionIds);
-
             _eventValidationService.CheckIfProvidedOptionsAreValid(chosenOptions, eventEntity.SelectedOptions);
             _eventValidationService.CheckIfJoiningNotEnoughChoicesProvided(eventEntity.MaxChoices, legacyChosenCount);
             _eventValidationService.CheckIfJoiningTooManyChoicesProvided(eventEntity.MaxChoices, legacyChosenCount);
@@ -337,6 +332,9 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
                 OptionRules.IgnoreSingleJoin);
 
             _eventValidationService.CheckIfUserParticipatesInEvent(changeOptionsDto.UserId, eventEntity.Participants);
+
+            // After the capacity and membership rules, so those keep reporting their own codes.
+            _eventAnswerValidator.Validate(eventEntity.Questions, chosenOptions, legacyOptionIds);
 
             await ValidateSingleJoinForSameTypeEventsAsync(eventEntity, changeOptionsDto.OrganizationId, changeOptionsDto.UserId);
 
@@ -358,10 +356,6 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
 
             _eventValidationService.CheckIfRegistrationDeadlineIsExpired(eventDto.RegistrationDeadline);
 
-            // Ahead of CheckIfProvidedOptionsAreValid, so an unknown option reaches the client as
-            // the structured payload naming it rather than a bare code.
-            _eventAnswerValidator.Validate(eventDto.Questions, chosenOptions, legacyOptionIds);
-
             _eventValidationService.CheckIfProvidedOptionsAreValid(chosenOptions, eventDto.SelectedOptions);
             _eventValidationService.CheckIfJoiningNotEnoughChoicesProvided(eventDto.MaxChoices, legacyChosenCount);
             _eventValidationService.CheckIfJoiningTooManyChoicesProvided(eventDto.MaxChoices, legacyChosenCount);
@@ -374,6 +368,12 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
 
             _eventValidationService.CheckIfJoinAttendStatusIsValid(joinDto.AttendStatus, eventDto);
             _eventValidationService.CheckIfCanJoinEvent(joinDto, eventDto);
+
+            // Last, so "event is full" and the option-count codes are not masked by an answer
+            // error. CheckIfProvidedOptionsAreValid above already rejects an unknown option with
+            // code 215, which the web client has a message for, so UnknownOption here is a
+            // backstop for callers that skip that check.
+            _eventAnswerValidator.Validate(eventDto.Questions, chosenOptions, legacyOptionIds);
         }
 
         private void NotifyManagers(IEnumerable<UserEventAttendStatusChangeEmailDto> userEventAttendStatusChangeEmailDtos)

--- a/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
@@ -44,6 +44,7 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
         private readonly IEventValidationService _eventValidationService;
         private readonly IWallService _wallService;
         private readonly IAsyncRunner _asyncRunner;
+        private readonly IEventAnswerValidator _eventAnswerValidator;
 
         public EventParticipationService(IUnitOfWork2 uow,
             ISystemClock systemClock,
@@ -51,7 +52,8 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
             IPermissionService permissionService,
             IEventValidationService eventValidationService,
             IWallService wallService,
-            IAsyncRunner asyncRunner)
+            IAsyncRunner asyncRunner,
+            IEventAnswerValidator eventAnswerValidator)
         {
             _uow = uow;
             _eventsDbSet = _uow.GetDbSet<Event>();
@@ -64,6 +66,7 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
             _roleService = roleService;
             _wallService = wallService;
             _asyncRunner = asyncRunner;
+            _eventAnswerValidator = eventAnswerValidator;
         }
 
         public async Task ResetVirtualAttendeesAsync(Event @event, UserAndOrganizationDto userOrg) =>
@@ -335,16 +338,19 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
 
         private void ValidateEventBeforeJoin(EventJoinDto joinDto, EventJoinValidationDto eventDto)
         {
+            var chosenOptions = joinDto.ChosenOptions.ToList();
             var legacyOptionIds = LegacyOptionIds(eventDto.Options);
-            var legacyChosenCount = joinDto.ChosenOptions.Count(legacyOptionIds.Contains);
+            var legacyChosenCount = chosenOptions.Count(legacyOptionIds.Contains);
 
             _eventValidationService.CheckIfRegistrationDeadlineIsExpired(eventDto.RegistrationDeadline);
-            _eventValidationService.CheckIfProvidedOptionsAreValid(joinDto.ChosenOptions, eventDto.SelectedOptions);
+            _eventValidationService.CheckIfProvidedOptionsAreValid(chosenOptions, eventDto.SelectedOptions);
             _eventValidationService.CheckIfJoiningNotEnoughChoicesProvided(eventDto.MaxChoices, legacyChosenCount);
             _eventValidationService.CheckIfJoiningTooManyChoicesProvided(eventDto.MaxChoices, legacyChosenCount);
             _eventValidationService.CheckIfSingleChoiceSelectedWithRule(eventDto.SelectedOptions, OptionRules.IgnoreSingleJoin);
             _eventValidationService.CheckIfJoinAttendStatusIsValid(joinDto.AttendStatus, eventDto);
             _eventValidationService.CheckIfCanJoinEvent(joinDto, eventDto);
+
+            _eventAnswerValidator.Validate(eventDto.Questions, chosenOptions, legacyOptionIds);
         }
 
         private void NotifyManagers(IEnumerable<UserEventAttendStatusChangeEmailDto> userEventAttendStatusChangeEmailDtos)
@@ -594,6 +600,18 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
                 MaxChoices = e.MaxChoices,
                 Id = e.Id,
                 Options = e.EventOptions,
+                Questions = e.EventQuestions
+                    .OrderBy(q => q.Order)
+                    .Select(q => new ResolvedEventQuestionDto
+                    {
+                        QuestionId = q.Id,
+                        Order = q.Order,
+                        SelectType = q.SelectType,
+                        IsRequired = q.IsRequired,
+                        ShowIfOptionId = q.ShowIfOptionId,
+                        OptionIds = q.Options.Select(o => o.Id).ToList()
+                    })
+                    .ToList(),
                 IsSingleJoin = e.EventType.IsSingleJoin,
                 EventTypeId = e.EventTypeId,
                 SingleJoinGroupName = e.EventType.SingleJoinGroupName,
@@ -714,6 +732,7 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
             var eventDto = await _eventsDbSet
                 .Include(x => x.EventParticipants)
                 .Include(x => x.EventOptions)
+                .Include(x => x.EventQuestions).ThenInclude(q => q.Options)
                 .Include(x => x.EventType)
                 .Where(x => x.Id == joinDto.EventId && x.OrganizationId == joinDto.OrganizationId)
                 .Select(MapEventToJoinValidationDto)

--- a/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
@@ -311,10 +311,13 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
                 .Where(option => changeOptionsDto.ChosenOptions.Contains(option.Id))
                 .ToList();
 
+            var legacyOptionIds = LegacyOptionIds(eventEntity.Options);
+            var legacyChosenCount = changeOptionsDto.ChosenOptions.Count(legacyOptionIds.Contains);
+
             _eventValidationService.CheckIfRegistrationDeadlineIsExpired(eventEntity.RegistrationDeadline);
             _eventValidationService.CheckIfProvidedOptionsAreValid(changeOptionsDto.ChosenOptions, eventEntity.SelectedOptions);
-            _eventValidationService.CheckIfJoiningNotEnoughChoicesProvided(eventEntity.MaxChoices, changeOptionsDto.ChosenOptions.Count());
-            _eventValidationService.CheckIfJoiningTooManyChoicesProvided(eventEntity.MaxChoices, changeOptionsDto.ChosenOptions.Count());
+            _eventValidationService.CheckIfJoiningNotEnoughChoicesProvided(eventEntity.MaxChoices, legacyChosenCount);
+            _eventValidationService.CheckIfJoiningTooManyChoicesProvided(eventEntity.MaxChoices, legacyChosenCount);
             _eventValidationService.CheckIfSingleChoiceSelectedWithRule(eventEntity.SelectedOptions, OptionRules.IgnoreSingleJoin);
             _eventValidationService.CheckIfUserParticipatesInEvent(changeOptionsDto.UserId, eventEntity.Participants);
 
@@ -332,10 +335,13 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
 
         private void ValidateEventBeforeJoin(EventJoinDto joinDto, EventJoinValidationDto eventDto)
         {
+            var legacyOptionIds = LegacyOptionIds(eventDto.Options);
+            var legacyChosenCount = joinDto.ChosenOptions.Count(legacyOptionIds.Contains);
+
             _eventValidationService.CheckIfRegistrationDeadlineIsExpired(eventDto.RegistrationDeadline);
             _eventValidationService.CheckIfProvidedOptionsAreValid(joinDto.ChosenOptions, eventDto.SelectedOptions);
-            _eventValidationService.CheckIfJoiningNotEnoughChoicesProvided(eventDto.MaxChoices, joinDto.ChosenOptions.Count());
-            _eventValidationService.CheckIfJoiningTooManyChoicesProvided(eventDto.MaxChoices, joinDto.ChosenOptions.Count());
+            _eventValidationService.CheckIfJoiningNotEnoughChoicesProvided(eventDto.MaxChoices, legacyChosenCount);
+            _eventValidationService.CheckIfJoiningTooManyChoicesProvided(eventDto.MaxChoices, legacyChosenCount);
             _eventValidationService.CheckIfSingleChoiceSelectedWithRule(eventDto.SelectedOptions, OptionRules.IgnoreSingleJoin);
             _eventValidationService.CheckIfJoinAttendStatusIsValid(joinDto.AttendStatus, eventDto);
             _eventValidationService.CheckIfCanJoinEvent(joinDto, eventDto);
@@ -731,6 +737,17 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
         private List<EventOption> GetSelectedOptions(EventJoinValidationDto validationDto, EventJoinDto joinDto) =>
             validationDto.Options.Where(option => joinDto.ChosenOptions.Contains(option.Id))
                 .ToList();
+
+        // MaxChoices is derived from flat options only (see EventService.FindOutMaxChoices), so a
+        // question-only event has MaxChoices == 0. Counting answers against it rejects every valid
+        // submission. Question answers are bounded by EventAnswerValidator instead.
+        private static List<int> LegacyOptionIds(ICollection<EventOption> allOptions)
+        {
+            return allOptions
+                .Where(option => option.QuestionId == null)
+                .Select(option => option.Id)
+                .ToList();
+        }
 
         private void SendEventInvitations(EventJoinDto joinDto, EventJoinValidationDto eventDto) =>
             _asyncRunner.Run<IEventCalendarService>(async notifier =>

--- a/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/Participation/EventParticipationService.cs
@@ -311,11 +311,33 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
             _eventValidationService.CheckIfEventExists(eventEntity);
 
             // ReSharper disable once PossibleNullReferenceException
+            var submitted = SubmittedOptionIds(changeOptionsDto.ChosenOptions, changeOptionsDto.Answers);
+
+            // Whether the request touches answers is decided by the event's own data, not by which
+            // field the ids arrived in: a caller that puts answers in ChosenOptions is still
+            // answering, and must face the answer rules.
+            var questionOwnedIds = eventEntity.Options
+                .Where(option => option.QuestionId != null)
+                .Select(option => option.Id)
+                .ToHashSet();
+
+            var answersSupplied = changeOptionsDto.Answers != null || submitted.Any(questionOwnedIds.Contains);
+
+            // A flat-options-only payload leaves the stored answers alone. The legacy web client
+            // posts exactly that, so replacing the whole selection with it would delete answers it
+            // never knew about, and enforcing the stored ones would block a food-choice change the
+            // moment a host adds a required question.
+            var chosenOptions = answersSupplied
+                ? submitted
+                : submitted
+                    .Concat(await StoredAnswerIdsAsync(changeOptionsDto.EventId, changeOptionsDto.UserId))
+                    .Distinct()
+                    .ToList();
+
             eventEntity.SelectedOptions = eventEntity.Options
-                .Where(option => changeOptionsDto.ChosenOptions.Contains(option.Id))
+                .Where(option => chosenOptions.Contains(option.Id))
                 .ToList();
 
-            var chosenOptions = changeOptionsDto.ChosenOptions.ToList();
             var legacyOptionIds = LegacyOptionIds(eventEntity.Options);
             var legacyChosenCount = chosenOptions.Count(legacyOptionIds.Contains);
 
@@ -334,7 +356,12 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
             _eventValidationService.CheckIfUserParticipatesInEvent(changeOptionsDto.UserId, eventEntity.Participants);
 
             // After the capacity and membership rules, so those keep reporting their own codes.
-            _eventAnswerValidator.Validate(eventEntity.Questions, chosenOptions);
+            // Only when the caller actually submitted answers: re-validating stored ones would turn
+            // a later tree change into a permanent block on changing options.
+            if (answersSupplied)
+            {
+                _eventAnswerValidator.Validate(eventEntity.Questions, chosenOptions);
+            }
 
             await ValidateSingleJoinForSameTypeEventsAsync(eventEntity, changeOptionsDto.OrganizationId, changeOptionsDto.UserId);
 
@@ -350,7 +377,7 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
 
         private void ValidateEventBeforeJoin(EventJoinDto joinDto, EventJoinValidationDto eventDto)
         {
-            var chosenOptions = joinDto.ChosenOptions.ToList();
+            var chosenOptions = SubmittedOptionIds(joinDto.ChosenOptions, joinDto.Answers);
             var legacyOptionIds = LegacyOptionIds(eventDto.Options);
             var legacyChosenCount = chosenOptions.Count(legacyOptionIds.Contains);
 
@@ -783,9 +810,32 @@ namespace Shrooms.Premium.Domain.Services.Events.Participation
             _eventValidationService.CheckIfUserHasPermission(joinDto.UserId, eventDto.ResponsibleUserId, hasPermission);
         }
 
-        private List<EventOption> GetSelectedOptions(EventJoinValidationDto validationDto, EventJoinDto joinDto) =>
-            validationDto.Options.Where(option => joinDto.ChosenOptions.Contains(option.Id))
+        private List<EventOption> GetSelectedOptions(EventJoinValidationDto validationDto, EventJoinDto joinDto)
+        {
+            var submitted = SubmittedOptionIds(joinDto.ChosenOptions, joinDto.Answers);
+
+            return validationDto.Options.Where(option => submitted.Contains(option.Id)).ToList();
+        }
+
+        // The two id kinds travel in separate fields, but every rule downstream partitions them by
+        // the event's own QuestionId, so a caller that lumps them together still behaves.
+        private static List<int> SubmittedOptionIds(IEnumerable<int> chosenOptions, IEnumerable<int> answers)
+        {
+            return (chosenOptions ?? Enumerable.Empty<int>())
+                .Concat(answers ?? Enumerable.Empty<int>())
+                .Distinct()
                 .ToList();
+        }
+
+        private async Task<List<int>> StoredAnswerIdsAsync(Guid eventId, string userId)
+        {
+            return await _eventParticipantsDbSet
+                .Where(participant => participant.EventId == eventId && participant.ApplicationUserId == userId)
+                .SelectMany(participant => participant.EventOptions
+                    .Where(option => option.QuestionId != null)
+                    .Select(option => option.Id))
+                .ToListAsync();
+        }
 
         // MaxChoices is derived from flat options only (see EventService.FindOutMaxChoices), so a
         // question-only event has MaxChoices == 0. Counting answers against it rejects every valid

--- a/src/api/Shrooms.Premium/Domain/Services/Events/Utilities/EventUtilitiesService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/Events/Utilities/EventUtilitiesService.cs
@@ -197,6 +197,7 @@ namespace Shrooms.Premium.Domain.Services.Events.Utilities
                 .Include(e => e.EventParticipants)
                 .Include(e => e.Event)
                 .Where(e => e.EventId == eventId
+                    && e.QuestionId == null
                     && e.Event.OrganizationId == userAndOrg.OrganizationId
                     && e.EventParticipants.Any(x => x.EventId == eventId))
                 .Select(e => new EventOptionCountDto

--- a/src/api/Shrooms.Premium/Domain/Services/WebHookCallbacks/Events/EventsWebHookService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/WebHookCallbacks/Events/EventsWebHookService.cs
@@ -27,6 +27,7 @@ namespace Shrooms.Premium.Domain.Services.WebHookCallbacks.Events
         private readonly DbSet<EventOption> _eventOptionsDbSet;
         private readonly IUnitOfWork2 _uow;
         private readonly ISystemClock _systemClock;
+        private readonly DbSet<EventQuestion> _questionsDbSet;
         private readonly IWallService _wallService;
         private readonly IApplicationSettings _appSettings;
 
@@ -35,6 +36,7 @@ namespace Shrooms.Premium.Domain.Services.WebHookCallbacks.Events
             _uow = uow;
             _eventsDbSet = uow.GetDbSet<Event>();
             _eventOptionsDbSet = uow.GetDbSet<EventOption>();
+            _questionsDbSet = uow.GetDbSet<EventQuestion>();
 
             _systemClock = systemClock;
             _wallService = wallService;
@@ -45,6 +47,7 @@ namespace Shrooms.Premium.Domain.Services.WebHookCallbacks.Events
         {
             var eventsToUpdate = await _eventsDbSet
                     .Include(e => e.EventOptions)
+                    .Include(e => e.EventQuestions).ThenInclude(q => q.Options)
                     .Include(u => u.ResponsibleUser)
                     .Where(e => e.EventRecurring != EventRecurrenceOptions.None && e.EndDate < _systemClock.UtcNow && e.ResponsibleUser != null)
                     .ToListAsync();
@@ -56,6 +59,7 @@ namespace Shrooms.Premium.Domain.Services.WebHookCallbacks.Events
                 _eventsDbSet.Add(newEvent);
                 @event.EventRecurring = EventRecurrenceOptions.None;
                 CreateNewOptions(@event.EventOptions, newEvent);
+                CreateNewQuestions(@event.EventQuestions, newEvent);
             }
 
             await _uow.SaveChangesAsync(false);
@@ -110,7 +114,10 @@ namespace Shrooms.Premium.Domain.Services.WebHookCallbacks.Events
         private void CreateNewOptions(IEnumerable<EventOption> expiredEventOptions, Event newEvent)
         {
             var timestamp = _systemClock.UtcNow;
-            foreach (var option in expiredEventOptions)
+
+            // Legacy flat options only. A question-owned option cloned loose would surface on the
+            // next occurrence as a top-level food choice, and MaxChoices does not account for it.
+            foreach (var option in expiredEventOptions.Where(option => option.QuestionId == null))
             {
                 _eventOptionsDbSet.Add(new EventOption
                 {
@@ -119,8 +126,70 @@ namespace Shrooms.Premium.Domain.Services.WebHookCallbacks.Events
                     CreatedBy = option.CreatedBy,
                     ModifiedBy = option.ModifiedBy,
                     Option = option.Option,
+                    Rule = option.Rule,
+                    Order = option.Order,
                     Event = newEvent
                 });
+            }
+        }
+
+        /// <summary>
+        /// Clones the question tree onto the next occurrence. Conditions are rewired through the
+        /// navigation property, since the cloned options have no identity until SaveChanges.
+        /// </summary>
+        private void CreateNewQuestions(IEnumerable<EventQuestion> expiredQuestions, Event newEvent)
+        {
+            var timestamp = _systemClock.UtcNow;
+            var clonedOptionByOldId = new Dictionary<int, EventOption>();
+            var clones = new List<(EventQuestion Old, EventQuestion New)>();
+
+            foreach (var question in expiredQuestions.OrderBy(question => question.Order))
+            {
+                var clone = new EventQuestion
+                {
+                    Created = timestamp,
+                    Modified = timestamp,
+                    CreatedBy = question.CreatedBy,
+                    ModifiedBy = question.ModifiedBy,
+                    Title = question.Title,
+                    Order = question.Order,
+                    SelectType = question.SelectType,
+                    IsRequired = question.IsRequired,
+                    Event = newEvent,
+                    Options = new List<EventOption>()
+                };
+
+                foreach (var option in question.Options ?? new List<EventOption>())
+                {
+                    var optionClone = new EventOption
+                    {
+                        Created = timestamp,
+                        Modified = timestamp,
+                        CreatedBy = option.CreatedBy,
+                        ModifiedBy = option.ModifiedBy,
+                        Option = option.Option,
+                        Rule = option.Rule,
+                        Order = option.Order,
+                        Event = newEvent,
+                        Question = clone
+                    };
+
+                    clone.Options.Add(optionClone);
+                    clonedOptionByOldId[option.Id] = optionClone;
+                    _eventOptionsDbSet.Add(optionClone);
+                }
+
+                _questionsDbSet.Add(clone);
+                clones.Add((question, clone));
+            }
+
+            foreach (var (old, clone) in clones)
+            {
+                if (old.ShowIfOptionId != null &&
+                    clonedOptionByOldId.TryGetValue(old.ShowIfOptionId.Value, out var trigger))
+                {
+                    clone.ShowIfOption = trigger;
+                }
             }
         }
     }

--- a/src/api/Shrooms.Premium/Domain/Services/WebHookCallbacks/Events/EventsWebHookService.cs
+++ b/src/api/Shrooms.Premium/Domain/Services/WebHookCallbacks/Events/EventsWebHookService.cs
@@ -174,9 +174,9 @@ namespace Shrooms.Premium.Domain.Services.WebHookCallbacks.Events
                         Question = clone
                     };
 
+                    // Reached through clone.Options, so adding the question is enough to insert it.
                     clone.Options.Add(optionClone);
                     clonedOptionByOldId[option.Id] = optionClone;
-                    _eventOptionsDbSet.Add(optionClone);
                 }
 
                 _questionsDbSet.Add(clone);

--- a/src/api/Shrooms.Premium/IoC/Modules/EventsModule.cs
+++ b/src/api/Shrooms.Premium/IoC/Modules/EventsModule.cs
@@ -22,6 +22,9 @@ namespace Shrooms.Premium.IoC.Modules
             services.AddScoped<IEventUtilitiesService, EventUtilitiesService>();
             services.AddScoped<IEventValidationService, EventValidationService>();
             services.AddScoped<IEventParticipationService, EventParticipationService>();
+            services.AddScoped<IEventQuestionWriter, EventQuestionWriter>();
+            services.AddScoped<IEventQuestionStructureValidator, EventQuestionStructureValidator>();
+            services.AddScoped<IEventAnswerValidator, EventAnswerValidator>();
             return services;
         }
     }

--- a/src/api/Shrooms.Premium/Presentation/Api/Controllers/EventController.cs
+++ b/src/api/Shrooms.Premium/Presentation/Api/Controllers/EventController.cs
@@ -328,6 +328,7 @@ namespace Shrooms.Premium.Presentation.Api.Controllers
         {
             var eventJoinDto = _mapper.Map<EventJoinMultipleViewModel, EventJoinDto>(eventJoinModel);
             SetOrganizationAndUser(eventJoinDto);
+            eventJoinDto.Answers = eventJoinModel.Answers;
 
             try
             {
@@ -357,6 +358,7 @@ namespace Shrooms.Premium.Presentation.Api.Controllers
 
             var optionsDto = _mapper.Map<EventJoinViewModel, EventJoinDto>(joinOptions);
             SetOrganizationAndUser(optionsDto);
+            optionsDto.Answers = joinOptions.Answers;
             optionsDto.ParticipantIds = new List<string> { optionsDto.UserId };
 
             try
@@ -654,6 +656,7 @@ namespace Shrooms.Premium.Presentation.Api.Controllers
 
             var changeOptionsDto = _mapper.Map<EventChangeOptionViewModel, EventChangeOptionsDto>(viewModel);
             SetOrganizationAndUser(changeOptionsDto);
+            changeOptionsDto.Answers = viewModel.Answers;
 
             try
             {

--- a/src/api/Shrooms.Premium/Presentation/Api/Controllers/EventController.cs
+++ b/src/api/Shrooms.Premium/Presentation/Api/Controllers/EventController.cs
@@ -723,7 +723,6 @@ namespace Shrooms.Premium.Presentation.Api.Controllers
                     .Select(error => new EventAnswerErrorViewModel
                     {
                         QuestionId = error.QuestionId,
-                        OptionId = error.OptionId,
                         Reason = error.Reason
                     })
                     .ToList()

--- a/src/api/Shrooms.Premium/Presentation/Api/Controllers/EventController.cs
+++ b/src/api/Shrooms.Premium/Presentation/Api/Controllers/EventController.cs
@@ -718,11 +718,12 @@ namespace Shrooms.Premium.Presentation.Api.Controllers
         {
             return BadRequest(new EventAnswersInvalidViewModel
             {
-                Code = EventAnswersInvalidException.ErrorCode,
+                Code = PremiumErrorCodes.EventAnswersInvalid,
                 Errors = exception.Errors
                     .Select(error => new EventAnswerErrorViewModel
                     {
                         QuestionId = error.QuestionId,
+                        OptionId = error.OptionId,
                         Reason = error.Reason
                     })
                     .ToList()

--- a/src/api/Shrooms.Premium/Presentation/Api/Controllers/EventController.cs
+++ b/src/api/Shrooms.Premium/Presentation/Api/Controllers/EventController.cs
@@ -334,6 +334,10 @@ namespace Shrooms.Premium.Presentation.Api.Controllers
                 await _eventParticipationService.AddColleagueAsync(eventJoinDto);
                 return Ok();
             }
+            catch (EventAnswersInvalidException e)
+            {
+                return AnswersInvalid(e);
+            }
             catch (EventException e)
             {
                 return BadRequest(e.Message);
@@ -359,6 +363,10 @@ namespace Shrooms.Premium.Presentation.Api.Controllers
             {
                 await _eventParticipationService.JoinAsync(optionsDto);
                 return Ok();
+            }
+            catch (EventAnswersInvalidException e)
+            {
+                return AnswersInvalid(e);
             }
             catch (EventException e)
             {
@@ -652,6 +660,10 @@ namespace Shrooms.Premium.Presentation.Api.Controllers
                 await _eventParticipationService.UpdateSelectedOptionsAsync(changeOptionsDto);
                 return Ok();
             }
+            catch (EventAnswersInvalidException e)
+            {
+                return AnswersInvalid(e);
+            }
             catch (EventException e)
             {
                 return BadRequest(e.Message);
@@ -700,6 +712,21 @@ namespace Shrooms.Premium.Presentation.Api.Controllers
             {
                 return BadRequest(e.Message);
             }
+        }
+
+        private BadRequestObjectResult AnswersInvalid(EventAnswersInvalidException exception)
+        {
+            return BadRequest(new EventAnswersInvalidViewModel
+            {
+                Code = EventAnswersInvalidException.ErrorCode,
+                Errors = exception.Errors
+                    .Select(error => new EventAnswerErrorViewModel
+                    {
+                        QuestionId = error.QuestionId,
+                        Reason = error.Reason
+                    })
+                    .ToList()
+            });
         }
     }
 }

--- a/src/api/Shrooms.Premium/Presentation/ModelMappings/Profiles/EventsProfile.cs
+++ b/src/api/Shrooms.Premium/Presentation/ModelMappings/Profiles/EventsProfile.cs
@@ -68,7 +68,11 @@ namespace Shrooms.Premium.Presentation.ModelMappings.Profiles
                         }))
                 .ForMember(dest => dest.ShowIfOptionId, opt => opt.MapFrom(src => src.ShowIfOptionId));
 
+            // Answers is assigned by the controller: AutoMapper maps a null source collection to an
+            // empty destination one, which would erase the difference between "omitted" (keep the
+            // stored answers) and an empty array (clear them).
             CreateMap<EventChangeOptionViewModel, EventChangeOptionsDto>(MemberList.None)
+                .Ignore(x => x.Answers)
                 .Ignore(x => x.OrganizationId)
                 .Ignore(x => x.UserId);
 
@@ -91,10 +95,14 @@ namespace Shrooms.Premium.Presentation.ModelMappings.Profiles
                 .Ignore(d => d.Offices);
             CreateMap<MyEventsOptionsViewModel, MyEventsOptionsDto>(MemberList.None);
             CreateMap<EventSearchOptionsViewModel, EventSearchOptionsDto>(MemberList.None);
+            // Answers is assigned by the controller for the same reason as on
+            // EventChangeOptionViewModel: a null collection must not arrive as an empty one.
             CreateMap<EventJoinViewModel, EventJoinDto>(MemberList.None)
+                .Ignore(d => d.Answers)
                 .Ignore(d => d.ParticipantIds)
                 .IgnoreUserOrgDto();
             CreateMap<EventJoinMultipleViewModel, EventJoinDto>(MemberList.None)
+                .Ignore(d => d.Answers)
                 .Ignore(d => d.AttendComment)
                 .IgnoreUserOrgDto();
             CreateMap<EventOptionViewModel, EventOptionDto>(MemberList.None);

--- a/src/api/Shrooms.Premium/Presentation/ModelMappings/Profiles/EventsProfile.cs
+++ b/src/api/Shrooms.Premium/Presentation/ModelMappings/Profiles/EventsProfile.cs
@@ -49,6 +49,14 @@ namespace Shrooms.Premium.Presentation.ModelMappings.Profiles
                 .ForMember(dest => dest.OfficeIds, opt => opt.MapFrom(u => JsonConvert.DeserializeObject<string[]>(u.Offices.Value)));
             CreateMap<EventOptionsDto, EventOptionsViewModel>(MemberList.None);
 
+            // Read side. Id is non-null on anything that came out of the database, so the
+            // nullable write-side Id is flattened here rather than leaking a null to the client.
+            CreateMap<EventQuestionStructureDto, EventSignUpQuestionViewModel>(MemberList.None)
+                .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id ?? 0));
+
+            CreateMap<EventQuestionOptionStructureDto, EventSignUpOptionViewModel>(MemberList.None)
+                .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id ?? 0));
+
             CreateMap<EventQuestionStructureDto, EventQuestionViewModel>()
                 .ForMember(dest => dest.ShowIf, opt => opt.MapFrom(src =>
                     src.ShowIfOptionId == null && src.ShowIfOptionClientId == null

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventAnswerErrorViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventAnswerErrorViewModel.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Shrooms.Contracts.Enums;
+
+namespace Shrooms.Premium.Presentation.WebViewModels.Events
+{
+    public class EventAnswerErrorViewModel
+    {
+        /// <summary>Null when the failure has no owning question, as for an unknown option.</summary>
+        public int? QuestionId { get; set; }
+
+        /// <summary>Set when the failure names a specific option, as for an unknown option.</summary>
+        public int? OptionId { get; set; }
+
+        /// <summary>
+        /// Serialised as a string: no global string-enum converter is configured, and the wizard
+        /// branches on this value.
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public EventAnswerErrorReason Reason { get; set; }
+    }
+}

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventAnswerErrorViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventAnswerErrorViewModel.cs
@@ -6,11 +6,8 @@ namespace Shrooms.Premium.Presentation.WebViewModels.Events
 {
     public class EventAnswerErrorViewModel
     {
-        /// <summary>Null when the failure has no owning question, as for an unknown option.</summary>
-        public int? QuestionId { get; set; }
-
-        /// <summary>Set when the failure names a specific option, as for an unknown option.</summary>
-        public int? OptionId { get; set; }
+        /// <summary>The question the wizard should open on.</summary>
+        public int QuestionId { get; set; }
 
         /// <summary>
         /// Serialised as a string: no global string-enum converter is configured, and the wizard

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventAnswersInvalidViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventAnswersInvalidViewModel.cs
@@ -1,28 +1,15 @@
-using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Shrooms.Premium.DataTransferObjects.Models.Events;
+﻿using System.Collections.Generic;
 
 namespace Shrooms.Premium.Presentation.WebViewModels.Events
 {
     /// <summary>
     /// Machine-readable answer failures, so the wizard can open on the offending step instead of
-    /// showing a generic error. Reasons go over the wire as strings for the same reason
-    /// <see cref="EventSignUpQuestionViewModel.SelectType"/> does.
+    /// showing a generic error.
     /// </summary>
     public class EventAnswersInvalidViewModel
     {
         public string Code { get; set; }
 
         public IList<EventAnswerErrorViewModel> Errors { get; set; } = new List<EventAnswerErrorViewModel>();
-    }
-
-    public class EventAnswerErrorViewModel
-    {
-        /// <summary>Null for UnknownOption, which has no owning question.</summary>
-        public int? QuestionId { get; set; }
-
-        [JsonConverter(typeof(StringEnumConverter))]
-        public EventAnswerErrorReason Reason { get; set; }
     }
 }

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventAnswersInvalidViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventAnswersInvalidViewModel.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Shrooms.Premium.DataTransferObjects.Models.Events;
+
+namespace Shrooms.Premium.Presentation.WebViewModels.Events
+{
+    /// <summary>
+    /// Machine-readable answer failures, so the wizard can open on the offending step instead of
+    /// showing a generic error. Reasons go over the wire as strings for the same reason
+    /// <see cref="EventSignUpQuestionViewModel.SelectType"/> does.
+    /// </summary>
+    public class EventAnswersInvalidViewModel
+    {
+        public string Code { get; set; }
+
+        public IList<EventAnswerErrorViewModel> Errors { get; set; } = new List<EventAnswerErrorViewModel>();
+    }
+
+    public class EventAnswerErrorViewModel
+    {
+        /// <summary>Null for UnknownOption, which has no owning question.</summary>
+        public int? QuestionId { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public EventAnswerErrorReason Reason { get; set; }
+    }
+}

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventChangeOptionViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventChangeOptionViewModel.cs
@@ -11,5 +11,11 @@ namespace Shrooms.Premium.Presentation.WebViewModels.Events
 
         [Required]
         public IEnumerable<int> ChosenOptions { get; set; }
+
+        /// <summary>
+        /// Question answers. Omit the property to keep the stored answers, send an empty array to
+        /// clear them. Deliberately not [Required]: null and empty mean different things here.
+        /// </summary>
+        public IEnumerable<int> Answers { get; set; }
     }
 }

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventEditDetailsViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventEditDetailsViewModel.cs
@@ -50,6 +50,8 @@ namespace Shrooms.Premium.Presentation.WebViewModels.Events
 
         public IEnumerable<EventOptionViewModel> Options { get; set; }
 
+        public IEnumerable<EventSignUpQuestionViewModel> Questions { get; set; } = new List<EventSignUpQuestionViewModel>();
+
         public IEnumerable<EventReminderDetailsViewModel> Reminders { get; set; }
     }
 }

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventJoinMultipleViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventJoinMultipleViewModel.cs
@@ -16,5 +16,10 @@ namespace Shrooms.Premium.Presentation.WebViewModels.Events
         public ICollection<string> ParticipantIds { get; set; }
 
         public ICollection<int> ChosenOptions { get; set; }
+
+        /// <summary>
+        /// Question answers, applied to every participant being added.
+        /// </summary>
+        public ICollection<int> Answers { get; set; }
     }
 }

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventJoinViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventJoinViewModel.cs
@@ -15,5 +15,11 @@ namespace Shrooms.Premium.Presentation.WebViewModels.Events
         public string AttendComment { get; set; }
 
         public IEnumerable<int> ChosenOptions { get; set; }
+
+        /// <summary>
+        /// Question answers, kept apart from <see cref="ChosenOptions"/> so the flat food-style
+        /// options and the question tree can be validated under their own rules.
+        /// </summary>
+        public IEnumerable<int> Answers { get; set; }
     }
 }

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventOptionsViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventOptionsViewModel.cs
@@ -8,7 +8,7 @@ namespace Shrooms.Premium.Presentation.WebViewModels.Events
 
         public IEnumerable<EventOptionViewModel> Options { get; set; }
 
-        public IEnumerable<EventQuestionViewModel> Questions { get; set; } = new List<EventQuestionViewModel>();
+        public IEnumerable<EventSignUpQuestionViewModel> Questions { get; set; } = new List<EventSignUpQuestionViewModel>();
 
         public IEnumerable<int> MyChosenOptions { get; set; } = new List<int>();
     }

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventSignUpOptionViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventSignUpOptionViewModel.cs
@@ -1,0 +1,20 @@
+﻿using Shrooms.Contracts.Enums;
+
+namespace Shrooms.Premium.Presentation.WebViewModels.Events
+{
+    public class EventSignUpOptionViewModel
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public int Order { get; set; }
+
+        /// <summary>
+        /// Carried on the read shape so a client echoing this payload back does not reset a
+        /// stored rule. Rule on a question option feeds the single-join exemption checks, the
+        /// same as it does for a legacy option.
+        /// </summary>
+        public OptionRules? Rule { get; set; }
+    }
+}

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventSignUpOptionViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventSignUpOptionViewModel.cs
@@ -11,9 +11,9 @@ namespace Shrooms.Premium.Presentation.WebViewModels.Events
         public int Order { get; set; }
 
         /// <summary>
-        /// Carried on the read shape so a client echoing this payload back does not reset a
-        /// stored rule. Rule on a question option feeds the single-join exemption checks, the
-        /// same as it does for a legacy option.
+        /// Carried on the read shape only so a client echoing this payload back does not reset a
+        /// stored rule. It does not affect sign-up: both single-join checks are scoped to legacy
+        /// options, so IgnoreSingleJoin on a question option is never consulted.
         /// </summary>
         public OptionRules? Rule { get; set; }
     }

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventSignUpQuestionViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventSignUpQuestionViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Shrooms.Contracts.Enums;
@@ -29,14 +29,5 @@ namespace Shrooms.Premium.Presentation.WebViewModels.Events
         public int? ShowIfOptionId { get; set; }
 
         public IList<EventSignUpOptionViewModel> Options { get; set; } = new List<EventSignUpOptionViewModel>();
-    }
-
-    public class EventSignUpOptionViewModel
-    {
-        public int Id { get; set; }
-
-        public string Name { get; set; }
-
-        public int Order { get; set; }
     }
 }

--- a/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventSignUpQuestionViewModel.cs
+++ b/src/api/Shrooms.Premium/Presentation/WebViewModels/Events/EventSignUpQuestionViewModel.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Shrooms.Contracts.Enums;
+
+namespace Shrooms.Premium.Presentation.WebViewModels.Events
+{
+    /// <summary>
+    /// Read shape for the attendee wizard. Deliberately separate from
+    /// <see cref="EventQuestionViewModel"/>: that one is the write shape, carrying clientId and a
+    /// nested ShowIf object that mean nothing on read. Keeping them apart also lets SelectType go
+    /// over the wire as a string — no global string-enum converter is configured, so reusing the
+    /// write model would emit 0/1 and break the client.
+    /// </summary>
+    public class EventSignUpQuestionViewModel
+    {
+        public int Id { get; set; }
+
+        public string Title { get; set; }
+
+        public int Order { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public EventQuestionSelectType SelectType { get; set; }
+
+        public bool IsRequired { get; set; }
+
+        /// <summary>Null means the question is always shown.</summary>
+        public int? ShowIfOptionId { get; set; }
+
+        public IList<EventSignUpOptionViewModel> Options { get; set; } = new List<EventSignUpOptionViewModel>();
+    }
+
+    public class EventSignUpOptionViewModel
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public int Order { get; set; }
+    }
+}


### PR DESCRIPTION
Second of three, on top of #330 — review that first. Next: #332.

Persists the question tree on create/update, serves it from `/Events/Options` and
`/Events/Update`, and enforces answers on join, add-colleague and option changes.

Writes stage for the caller to commit and validate before anything mutates, so a
rejected payload leaves no orphan event. Question-owned options stay out of every
legacy path: `MaxChoices`, single-join gates, Excel export, food widget, rollover.
